### PR TITLE
chore: promote @sudomimus/native to alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository hosts client SDKs for the public Sudomimus APIs, organized by la
 | --- | --- | --- | --- |
 | TypeScript | [`@sudomimus/connect`](sdks/typescript/packages/connect) | Token exchange (Establish / StatusPoll / Redeem / Refresh / Info) | alpha |
 | TypeScript | [`@sudomimus/token`](sdks/typescript/packages/token) | Parse and verify Sudomimus access / refresh JWTs | alpha |
-| TypeScript | [`@sudomimus/native`](sdks/typescript/packages/native) | Native client entry point | scaffolded |
+| TypeScript | [`@sudomimus/native`](sdks/typescript/packages/native) | Direct-issue (Steam ticket / access key) | alpha |
 | Python | [`sudomimus-connect`](sdks/python/packages/sudomimus-connect) | Token exchange (Establish / Redeem / Refresh) | scaffolded |
 | Python | [`sudomimus-native`](sdks/python/packages/sudomimus-native) | Native client entry point | scaffolded |
 

--- a/sdks/typescript/packages/native/README.md
+++ b/sdks/typescript/packages/native/README.md
@@ -1,6 +1,6 @@
 # @sudomimus/native
 
-TypeScript SDK for the Sudomimus Native API — the public gateway used by native clients (desktop applications, games) to authenticate through an external browser.
+TypeScript SDK for the [Sudomimus](https://sudomimus.com) Native API — the direct-issue gateway for native clients (desktop apps, games, headless processes). The client presents a platform-issued proof (a Steam Web API auth ticket) or a long-lived access-key credential and receives application access + refresh tokens in a single round trip. No browser handoff, no inquiry establishment, no polling.
 
 ## Install
 
@@ -16,19 +16,75 @@ pnpm add @sudomimus/native
 import { NativeClient } from "@sudomimus/native";
 
 const client = new NativeClient({
-    baseUrl: "https://native.sudomimus.com",
+    baseUrl: "https://native-api.sudomimus.com",
 });
 ```
 
+### Steam ticket
+
+Acquire the ticket via Steamworks, hex-encode the bytes, and exchange it for tokens. The identity string passed to `GetAuthTicketForWebApi` MUST be exactly `"sudomimus"` — exported as `STEAM_TICKET_IDENTITY`.
+
+```typescript
+import { NativeClient, STEAM_TICKET_IDENTITY } from "@sudomimus/native";
+
+// 1. ISteamUser::GetAuthTicketForWebApi(STEAM_TICKET_IDENTITY)
+// 2. Wait for the GetTicketForWebApiResponse_t callback.
+// 3. Hex-encode the ticket bytes.
+
+const tokens = await client.directIssueSteamTicket({
+    applicationAnchor: "your-app-anchor",
+    steamTicketHex: "deadbeef...",
+    steamAppId: 480,
+});
+
+console.log(tokens.accessToken, tokens.refreshToken);
+```
+
+### Access key
+
+Trade an access-key credential (issued in the admin console) for tokens. Intended for long-lived headless callers — CI runners, server-to-server scripts, automation.
+
+```typescript
+const tokens = await client.directIssueAccessKey({
+    applicationAnchor: "your-app-anchor",
+    accessKeyIdentifier: "01890c5e-1234-4abc-9def-0123456789ab",
+    accessKeySecret: "<64-char lowercase hex secret>",
+});
+```
+
+### Renewing tokens
+
+The issued tokens share the shape of those minted by Connect's `/redeem`. Use [`@sudomimus/connect`](../connect)'s `/refresh` to renew the access token without re-presenting a Steam ticket or access key, and [`@sudomimus/token`](../token) to verify the issued JWTs.
+
+### Error handling
+
+All non-2xx HTTP responses surface as `NativeApiError`:
+
+```typescript
+import { NativeApiError } from "@sudomimus/native";
+
+try {
+    await client.directIssueAccessKey({ /* ... */ });
+} catch (err) {
+    if (err instanceof NativeApiError) {
+        console.error(err.status, err.reason);
+    }
+}
+```
+
+The Native service returns `{ "reason": "<code>" }` for known failures. All access-key credential failures collapse into an opaque `401 AccessKeyDirectDenied`; three-layer rule rejections surface as `403` with `Layer1Denied` / `Layer2Denied` / `Layer3Denied`; a replayed Steam ticket returns `409`. For `PRIVATE_*` symbols the body is empty — in that case `err.reason` and `err.body` are both `undefined` and only `err.status` carries signal.
+
 ## Types
 
-Request, response, and error types are generated from [`specs/native.yaml`](../../../../specs/native.yaml) and re-exported by name:
+HTTP request, response, and error types are generated from [`specs/native.yaml`](../../../../specs/native.yaml) and re-exported by name:
 
 ```typescript
 import type {
-    StatusPollRequest,
-    StatusPollResponse,
-    NativeError,
+    DirectIssueSteamTicketRequest,
+    DirectIssueSteamTicketResponse,
+    DirectIssueAccessKeyRequest,
+    DirectIssueAccessKeyResponse,
+    NativeErrorBody,
 } from "@sudomimus/native";
 ```
 

--- a/sdks/typescript/packages/native/package.json
+++ b/sdks/typescript/packages/native/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sudomimus/native",
-    "version": "0.0.1",
-    "description": "Sudomimus Native SDK — native client entry point.",
+    "version": "0.1.0",
+    "description": "Sudomimus Native SDK — direct-issue (Steam ticket, access key).",
     "license": "MIT",
     "repository": {
         "type": "git",
@@ -29,7 +29,10 @@
         "generate": "openapi-typescript ../../../../specs/native.yaml -o src/_generated/schema.ts",
         "compile": "tsc --project typescript/tsconfig.compile.json",
         "lint": "eslint src",
-        "test": "jest"
+        "test": "jest",
+        "release": "pnpm generate && pnpm lint && pnpm test && pnpm compile",
+        "release:dry-run": "pnpm release && pnpm pack --pack-destination /tmp && pnpm publish --dry-run --no-git-checks --access=public",
+        "release:publish": "pnpm release && pnpm publish --no-git-checks --access=public"
     },
     "devDependencies": {
         "@types/jest": "catalog:",


### PR DESCRIPTION
Rewrite the native README around the direct-issue flow (Steam ticket /
access key) instead of the stale browser-handoff copy, align the package
manifest with connect/token (0.1.0, release scripts), and update the repo
status table.

https://claude.ai/code/session_01BWJNhrSx8jVicAdxKLPsZJ