### PR TITLE
Implement Python SDKs to match the TypeScript/C# surface

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -44,4 +44,5 @@ jobs:
             exit 1
           fi
       - run: uv run ruff check
+      - run: uv run mypy packages/sudomimus-token/src packages/sudomimus-native/src packages/sudomimus-connect/src
       - run: uv run pytest

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 TS_SDK := sdks/typescript
 CSHARP_SDK := sdks/csharp
+PYTHON_SDK := sdks/python
+PYTHON_SRC := packages/sudomimus-token/src packages/sudomimus-native/src packages/sudomimus-connect/src
 NUGET_SOURCE := https://api.nuget.org/v3/index.json
 NUGET_PACK_DIR := $(CSHARP_SDK)/artifacts
 
@@ -78,6 +80,29 @@ lint-native:
 .PHONY: test-native
 test-native:
 	pnpm -C $(TS_SDK) --filter=@sudomimus/native run test
+
+# ---------- Python SDKs (sudomimus-token + sudomimus-native + sudomimus-connect) ----------
+# All -py targets operate on sdks/python/ (uv workspace).
+
+.PHONY: install-py
+install-py:
+	cd $(PYTHON_SDK) && uv sync
+
+.PHONY: generate-py
+generate-py:
+	cd $(PYTHON_SDK) && uv run python tasks.py generate
+
+.PHONY: lint-py
+lint-py:
+	cd $(PYTHON_SDK) && uv run ruff check
+
+.PHONY: typecheck-py
+typecheck-py:
+	cd $(PYTHON_SDK) && uv run mypy $(PYTHON_SRC)
+
+.PHONY: test-py
+test-py:
+	cd $(PYTHON_SDK) && uv run pytest
 
 # ---------- Publish ----------
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ This repository hosts client SDKs for the public Sudomimus APIs, organized by la
 | TypeScript | [`@sudomimus/connect`](sdks/typescript/packages/connect) | Token exchange (Establish / StatusPoll / Redeem / Refresh / Info) | alpha |
 | TypeScript | [`@sudomimus/token`](sdks/typescript/packages/token) | Parse and verify Sudomimus access / refresh JWTs | alpha |
 | TypeScript | [`@sudomimus/native`](sdks/typescript/packages/native) | Direct-issue (Steam ticket / access key) | alpha |
-| Python | [`sudomimus-connect`](sdks/python/packages/sudomimus-connect) | Token exchange (Establish / Redeem / Refresh) | scaffolded |
-| Python | [`sudomimus-native`](sdks/python/packages/sudomimus-native) | Native client entry point | scaffolded |
+| Python | [`sudomimus-connect`](sdks/python/packages/sudomimus-connect) | Token exchange (Establish / StatusPoll / Redeem / Refresh / Info) | alpha |
+| Python | [`sudomimus-token`](sdks/python/packages/sudomimus-token) | Parse and verify Sudomimus access / refresh JWTs | alpha |
+| Python | [`sudomimus-native`](sdks/python/packages/sudomimus-native) | Direct-issue (Steam ticket / access key) | alpha |
 
 ## Repository layout
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -6,8 +6,9 @@ This workspace hosts the Python SDKs published to PyPI.
 
 | Package | Spec | Purpose |
 | --- | --- | --- |
-| [`sudomimus-connect`](packages/sudomimus-connect) | [`specs/connect.yaml`](../../specs/connect.yaml) | Token exchange (Establish / Redeem / Refresh) |
-| [`sudomimus-native`](packages/sudomimus-native) | [`specs/native.yaml`](../../specs/native.yaml) | Native client entry point |
+| [`sudomimus-connect`](packages/sudomimus-connect) | [`specs/connect.yaml`](../../specs/connect.yaml) | Token exchange (Establish / StatusPoll / Redeem / Refresh / Info) |
+| [`sudomimus-token`](packages/sudomimus-token) | — (hand-written) | Parse and verify Sudomimus access / refresh JWTs |
+| [`sudomimus-native`](packages/sudomimus-native) | [`specs/native.yaml`](../../specs/native.yaml) | Direct-issue (Steam ticket / access key) |
 
 ## Tooling
 
@@ -24,7 +25,8 @@ cd sdks/python
 uv sync
 uv run python tasks.py generate    # regenerate packages/*/src/sudomimus_*/_generated/models.py
 uv run ruff check
+uv run mypy packages/sudomimus-token/src packages/sudomimus-native/src packages/sudomimus-connect/src
 uv run pytest
 ```
 
-Generated files live under `packages/*/src/sudomimus_*/_generated/` and are checked in. After editing a spec, run `uv run python tasks.py generate` and commit the regenerated files.
+Generated files live under `packages/*/src/sudomimus_*/_generated/` and are checked in. After editing a spec, run `uv run python tasks.py generate` and commit the regenerated files. `sudomimus-token` has no spec — its models are hand-written.

--- a/sdks/python/packages/sudomimus-connect/README.md
+++ b/sdks/python/packages/sudomimus-connect/README.md
@@ -1,6 +1,10 @@
 # sudomimus-connect
 
-Python SDK for the Sudomimus Connect API — token exchange (Establish, Redeem, Refresh).
+Python SDK for the Sudomimus Connect API — the token-exchange entry point:
+establish an authentication inquiry, poll its status, redeem it for
+application tokens, refresh access tokens, and fetch localized application
+metadata. Includes client-auth JWT signing for `/establish` and token
+verification (via [`sudomimus-token`](../sudomimus-token)).
 
 ## Install
 
@@ -10,24 +14,64 @@ pip install sudomimus-connect
 
 ## Usage
 
-```python
-from sudomimus_connect import ConnectClient
+`/establish` requires a client-auth JWT signed with your application's
+RS256 private key. Pass it via `client_auth`:
 
-client = ConnectClient(base_url="https://connect-api.sudomimus.com")
+```python
+from sudomimus_connect import (
+    ConnectClient,
+    ConnectClientAuthWithKey,
+    EstablishRequest,
+)
+
+with ConnectClient(
+    client_auth=ConnectClientAuthWithKey(
+        application_anchor="my-app",
+        private_key_pem=open("client-auth-private.pem").read(),
+    )
+) as client:
+    inquiry = client.establish(EstablishRequest(applicationAnchor="my-app"))
+    print(inquiry.exposureKey, inquiry.hiddenKey)
 ```
+
+The other endpoints need no client auth:
+
+```python
+status = client.status_poll(StatusPollRequest(exposureKey=..., hiddenKey=...))
+tokens = client.redeem(RedeemRequest(exposureKey=..., hiddenKey=..., confirmationKey=...))
+fresh = client.refresh(RefreshRequest(refreshToken=tokens.refreshToken))
+```
+
+Verify issued tokens (resolves and caches the application public key via
+`/info`):
+
+```python
+access = client.verify_access_token(tokens.accessToken)
+print(access.body.accountIdentifier)
+```
+
+An `AsyncConnectClient` with the same methods is available for `asyncio`
+callers (its BYO signer may be sync or async). Non-2xx responses raise
+`ConnectApiError` (inspect `.status` and `.reason`).
 
 ## Models
 
-Pydantic v2 models are generated from [`specs/connect.yaml`](../../../../specs/connect.yaml) and re-exported from the package root:
+Pydantic v2 models are generated from [`specs/connect.yaml`](../../../../specs/connect.yaml)
+and re-exported from the package root:
 
 ```python
 from sudomimus_connect import (
     ConnectError,
     EstablishRequest,
     EstablishResponse,
+    InfoRequest,
+    InfoResponse,
     RedeemRequest,
+    RedeemResponse,
     RefreshRequest,
-    TokenPair,
+    RefreshResponse,
+    StatusPollRequest,
+    StatusPollResponse,
 )
 ```
 

--- a/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/__init__.py
+++ b/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/__init__.py
@@ -1,54 +1,98 @@
 """Sudomimus Connect SDK.
 
-Token exchange client for the Sudomimus authentication platform.
+Token-exchange client for the Sudomimus authentication platform: establish an
+inquiry, poll its status, redeem it for application tokens, refresh access
+tokens, and fetch localized application metadata. Includes client-auth JWT
+signing for ``/establish`` and token verification (via ``sudomimus-token``).
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-import httpx
-
 from ._generated.models import (
-    Error as ConnectError,
-)
-from ._generated.models import (
+    AuthenticationRuleConstraint,
+    AuthenticationRuleEmailVerificationPayload,
+    AuthenticationRulePasskeyPayload,
     EstablishRequest,
     EstablishResponse,
+    HealthResponse,
+    InfoRequest,
+    InfoResponse,
+    RealizeRuleConstraint,
+    RealizeRuleEmailPayload,
     RedeemRequest,
+    RedeemResponse,
     RefreshRequest,
-    TokenPair,
+    RefreshResponse,
+    ReturnMethodCallback,
+    ReturnMethodDeclaration,
+    ReturnMethodReveal,
+    ReturnMethodStatusPoll,
+    StatusPollPendingResponse,
+    StatusPollRealizedResponse,
+    StatusPollRequest,
+    StatusPollResponse,
 )
+from ._generated.models import Error as ConnectError
+from .async_client import AsyncConnectClient
+from .client import ConnectClient
+from .client_auth import (
+    ClientAuthSigner,
+    ConnectClientAuth,
+    ConnectClientAuthWithKey,
+    ConnectClientAuthWithSigner,
+    build_establish_client_jwt_claims,
+    sha256_base64,
+    sign_establish_client_jwt,
+)
+from .constants import (
+    CLIENT_JWT_AUDIENCE,
+    CLIENT_JWT_AUTH_SCHEME,
+    CLIENT_JWT_DEFAULT_LIFETIME_SECONDS,
+    CLIENT_JWT_MAX_LIFETIME_SECONDS,
+    DEFAULT_PUBLIC_KEY_LOCALE,
+    PRODUCTION_BASE_URL,
+)
+from .errors import ConnectApiError, ConnectConfigError
 
 __all__ = [
+    "CLIENT_JWT_AUDIENCE",
+    "CLIENT_JWT_AUTH_SCHEME",
+    "CLIENT_JWT_DEFAULT_LIFETIME_SECONDS",
+    "CLIENT_JWT_MAX_LIFETIME_SECONDS",
+    "DEFAULT_PUBLIC_KEY_LOCALE",
+    "PRODUCTION_BASE_URL",
+    "AsyncConnectClient",
+    "AuthenticationRuleConstraint",
+    "AuthenticationRuleEmailVerificationPayload",
+    "AuthenticationRulePasskeyPayload",
+    "ClientAuthSigner",
+    "ConnectApiError",
     "ConnectClient",
-    "ConnectClientOptions",
+    "ConnectClientAuth",
+    "ConnectClientAuthWithKey",
+    "ConnectClientAuthWithSigner",
+    "ConnectConfigError",
     "ConnectError",
     "EstablishRequest",
     "EstablishResponse",
+    "HealthResponse",
+    "InfoRequest",
+    "InfoResponse",
+    "RealizeRuleConstraint",
+    "RealizeRuleEmailPayload",
     "RedeemRequest",
+    "RedeemResponse",
     "RefreshRequest",
-    "TokenPair",
+    "RefreshResponse",
+    "ReturnMethodCallback",
+    "ReturnMethodDeclaration",
+    "ReturnMethodReveal",
+    "ReturnMethodStatusPoll",
+    "StatusPollPendingResponse",
+    "StatusPollRealizedResponse",
+    "StatusPollRequest",
+    "StatusPollResponse",
+    "build_establish_client_jwt_claims",
+    "sha256_base64",
+    "sign_establish_client_jwt",
 ]
-
-
-@dataclass(slots=True)
-class ConnectClientOptions:
-    base_url: str
-
-
-class ConnectClient:
-    """Client for the Sudomimus Connect API."""
-
-    def __init__(
-        self,
-        *,
-        base_url: str,
-        transport: httpx.Client | None = None,
-    ) -> None:
-        self._base_url = base_url.rstrip("/")
-        self._transport = transport
-
-    @property
-    def base_url(self) -> str:
-        return self._base_url

--- a/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/_generated/models.py
+++ b/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/_generated/models.py
@@ -4,72 +4,250 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Any, Literal
 
-from pydantic import AnyUrl, AwareDatetime, BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 
-class EstablishRequest(BaseModel):
-    applicationKey: str = Field(
-        ..., description="Public key identifying the integrating application."
-    )
-    redirectUri: AnyUrl = Field(
-        ..., description="URI the platform will redirect to after authentication."
-    )
-    state: str | None = Field(
-        None,
-        description="Opaque value echoed back in the redirect for CSRF protection.",
-    )
+class HealthResponse(BaseModel):
+    ready: bool
+    service: str
+    version: str
 
 
 class EstablishResponse(BaseModel):
-    sessionId: str = Field(
-        ..., description="Identifier for the established connect session."
+    applicationAnchor: str
+    exposureKey: str = Field(
+        ...,
+        description="Public half of the inquiry key pair; safe to share with the user agent.",
     )
-    authorizeUrl: AnyUrl = Field(
-        ..., description="URL the end user should visit to complete authentication."
+    hiddenKey: str = Field(
+        ...,
+        description="Private half of the inquiry key pair; must stay on the originating client.",
     )
-    expiresAt: AwareDatetime | None = Field(
-        None, description="When this session will expire if unused."
+
+
+class StatusPollRequest(BaseModel):
+    exposureKey: str
+    hiddenKey: str
+
+
+class Status(StrEnum):
+    PENDING = "PENDING"
+
+
+class StatusPollPendingResponse(BaseModel):
+    status: Literal["PENDING"]
+
+
+class Status1(StrEnum):
+    REALIZED = "REALIZED"
+
+
+class StatusPollRealizedResponse(BaseModel):
+    status: Literal["REALIZED"]
+    confirmationKey: str = Field(
+        ...,
+        description="One-time key proving the inquiry has been realized; pass to /redeem.",
     )
 
 
 class RedeemRequest(BaseModel):
-    sessionId: str = Field(
-        ..., description="Session identifier returned from /establish."
-    )
-    code: str = Field(
-        ..., description="Authentication code obtained after the end user signs in."
-    )
+    exposureKey: str
+    hiddenKey: str
+    confirmationKey: str
+
+
+class RedeemResponse(BaseModel):
+    applicationAnchor: str
+    refreshToken: str = Field(..., description="Long-lived refresh token (JWT).")
+    accessToken: str = Field(..., description="Short-lived access token (JWT).")
 
 
 class RefreshRequest(BaseModel):
-    refreshToken: str = Field(
-        ..., description="Refresh token previously issued by /redeem or /refresh."
-    )
+    refreshToken: str
 
 
-class TokenType(StrEnum):
-    """
-    Token type; currently always "Bearer".
-    """
-
-    Bearer = "Bearer"
-
-
-class TokenPair(BaseModel):
+class RefreshResponse(BaseModel):
     accessToken: str = Field(
-        ..., description="Short-lived application access token (JWT)."
+        ...,
+        description="Short-lived access token (JWT). No new refresh token is issued.",
     )
-    refreshToken: str = Field(..., description="Long-lived refresh token.")
-    expiresIn: int = Field(..., description="Lifetime of the access token in seconds.")
-    tokenType: TokenType | None = Field(
-        "Bearer", description='Token type; currently always "Bearer".'
+
+
+class InfoRequest(BaseModel):
+    applicationAnchor: str
+    locale: str = Field(
+        ...,
+        description='IETF BCP 47 locale tag (e.g. "en-US"). Falls back to the application\'s default locale if not available.',
+    )
+
+
+class InfoResponse(BaseModel):
+    applicationAnchor: str
+    applicationName: str = Field(..., description="Localized application display name.")
+    applicationPublicKey: str = Field(
+        ...,
+        description="PEM-encoded application public key used to verify issued JWTs.",
+    )
+
+
+class Method(StrEnum):
+    """
+    Which authentication method this constraint narrows to.
+    """
+
+    PASSKEY = "PASSKEY"
+    EMAIL_VERIFICATION = "EMAIL_VERIFICATION"
+
+
+class AuthenticationRulePasskeyPayload(BaseModel):
+    """
+    Empty payload — passkey constraints carry no further parameters.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+
+
+class AuthenticationRuleEmailVerificationPayload(BaseModel):
+    """
+    Empty payload — email-verification constraints carry no further parameters.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+
+
+class ConstraintType(StrEnum):
+    """
+    Which realize-rule kind this constraint narrows to.
+    """
+
+    EMAIL = "EMAIL"
+
+
+class RealizeRuleEmailPayload(BaseModel):
+    allowedEmails: list[str] = Field(
+        ...,
+        description="List of email addresses or glob patterns the realized identity\nmust match. Glob patterns are bounded by server-side limits to\nprevent regex backtracking attacks.\n",
+    )
+
+
+class Type(StrEnum):
+    CALLBACK = "CALLBACK"
+
+
+class Payload(BaseModel):
+    callbackUrl: str = Field(
+        ...,
+        description="Concrete callback URL for this inquiry. The host MUST match\none of the application's allowed callback domains.\n",
+    )
+
+
+class ReturnMethodCallback(BaseModel):
+    type: Literal["CALLBACK"]
+    payload: Payload
+
+
+class Type1(StrEnum):
+    STATUS_POLL = "STATUS_POLL"
+
+
+class ReturnMethodStatusPoll(BaseModel):
+    type: Literal["STATUS_POLL"]
+    payload: dict[str, Any] = Field(
+        ...,
+        description="Empty payload — STATUS_POLL carries no per-inquiry parameters.",
+    )
+
+
+class Type2(StrEnum):
+    REVEAL = "REVEAL"
+
+
+class ReturnMethodReveal(BaseModel):
+    type: Literal["REVEAL"]
+    payload: dict[str, Any] = Field(
+        ..., description="Empty payload — REVEAL surfaces tokens directly in the UI."
     )
 
 
 class Error(BaseModel):
-    code: str = Field(..., description="Stable machine-readable error code.")
-    message: str = Field(..., description="Human-readable error message.")
-    requestId: str | None = Field(
-        None, description="Identifier for correlating with platform logs."
+    """
+    Error response body. The Connect service emits `{ "reason": "<SymbolDescription>" }`
+    for known failure modes. When the reason symbol's description begins with
+    `PRIVATE`, the body is empty (zero bytes) and only the HTTP status carries
+    signal — both `reason` and the body itself are absent in that case.
+
+    """
+
+    reason: str | None = Field(None, description="Stable machine-readable reason code.")
+
+
+class StatusPollResponse(
+    RootModel[StatusPollPendingResponse | StatusPollRealizedResponse]
+):
+    root: StatusPollPendingResponse | StatusPollRealizedResponse = Field(
+        ..., discriminator="status"
+    )
+
+
+class AuthenticationRuleConstraint(BaseModel):
+    method: Method = Field(
+        ..., description="Which authentication method this constraint narrows to."
+    )
+    payload: (
+        AuthenticationRulePasskeyPayload | AuthenticationRuleEmailVerificationPayload
+    )
+    accessTokenTtlSeconds: int | None = Field(
+        None,
+        description="Per-constraint override for access token lifetime. Resolved at realize time.",
+    )
+    refreshTokenTtlSeconds: int | None = Field(
+        None,
+        description="Per-constraint override for refresh token lifetime. Resolved at realize time.",
+    )
+
+
+class RealizeRuleConstraint(BaseModel):
+    constraintType: ConstraintType = Field(
+        ..., description="Which realize-rule kind this constraint narrows to."
+    )
+    payload: RealizeRuleEmailPayload
+    accessTokenTtlSeconds: int | None = Field(
+        None,
+        description="Per-constraint override for access token lifetime. Resolved at realize time.",
+    )
+    refreshTokenTtlSeconds: int | None = Field(
+        None,
+        description="Per-constraint override for refresh token lifetime. Resolved at realize time.",
+    )
+
+
+class ReturnMethodDeclaration(
+    RootModel[ReturnMethodCallback | ReturnMethodStatusPoll | ReturnMethodReveal]
+):
+    root: ReturnMethodCallback | ReturnMethodStatusPoll | ReturnMethodReveal = Field(
+        ..., discriminator="type"
+    )
+
+
+class EstablishRequest(BaseModel):
+    applicationAnchor: str = Field(
+        ..., description="Public anchor identifying the integrating application."
+    )
+    authenticationConstraints: list[AuthenticationRuleConstraint] | None = Field(
+        None,
+        description="Optional per-inquiry narrowing of the application's\nauthentication-rule layer. Absent means no narrowing. If present,\nthe array MUST be non-empty; empty arrays are rejected with 400.\n",
+    )
+    realizeConstraints: list[RealizeRuleConstraint] | None = Field(
+        None,
+        description="Optional per-inquiry narrowing of the application's realize-rule\nlayer. Absent means no narrowing. If present, the array MUST be\nnon-empty; empty arrays are rejected with 400.\n",
+    )
+    returnMethods: list[ReturnMethodDeclaration] | None = Field(
+        None,
+        description="Optional per-inquiry return-method declaration. Doubles as the\nconcrete delivery info for CALLBACK (carries the callback URL).\nAbsent means no per-inquiry narrowing (CALLBACK is unreachable\nfor this inquiry because no URL is anchored). If present, the\narray MUST be non-empty; empty arrays are rejected with 400.\n",
     )

--- a/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/async_client.py
+++ b/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/async_client.py
@@ -1,0 +1,160 @@
+"""Asynchronous Connect API HTTP client."""
+
+from __future__ import annotations
+
+import inspect
+from types import TracebackType
+from typing import TypeVar
+
+import httpx
+from pydantic import BaseModel
+from sudomimus_token import AccessToken, AsyncTokenVerifier, RefreshToken
+
+from ._generated.models import (
+    EstablishRequest,
+    EstablishResponse,
+    HealthResponse,
+    InfoRequest,
+    InfoResponse,
+    RedeemRequest,
+    RedeemResponse,
+    RefreshRequest,
+    RefreshResponse,
+    StatusPollRequest,
+    StatusPollResponse,
+)
+from .client import _JSON_HEADERS, _handle
+from .client_auth import (
+    ConnectClientAuth,
+    ConnectClientAuthWithSigner,
+    sign_establish_client_jwt,
+)
+from .constants import (
+    CLIENT_JWT_AUTH_SCHEME,
+    DEFAULT_PUBLIC_KEY_LOCALE,
+    PRODUCTION_BASE_URL,
+)
+from .errors import ConnectConfigError
+
+_ResponseT = TypeVar("_ResponseT", bound=BaseModel)
+
+
+class AsyncConnectClient:
+    """Async client for the Sudomimus Connect API."""
+
+    def __init__(
+        self,
+        base_url: str = PRODUCTION_BASE_URL,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+        public_key_fetch_locale: str = DEFAULT_PUBLIC_KEY_LOCALE,
+        client_auth: ConnectClientAuth | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = http_client if http_client is not None else httpx.AsyncClient()
+        self._owns_client = http_client is None
+        self._public_key_locale = public_key_fetch_locale
+        self._client_auth = client_auth
+        self._public_key_cache: dict[str, str] = {}
+        self._verifier = AsyncTokenVerifier(self.get_application_public_key)
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    async def __aenter__(self) -> AsyncConnectClient:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client if this instance created it."""
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def health(self) -> HealthResponse:
+        response = await self._client.get(
+            f"{self._base_url}/health", headers={"Accept": "application/json"}
+        )
+        return _handle(response, HealthResponse)
+
+    async def establish(self, request: EstablishRequest) -> EstablishResponse:
+        if self._client_auth is None:
+            raise ConnectConfigError(
+                "AsyncConnectClient.establish() requires client_auth. "
+                "Pass client_auth to the AsyncConnectClient constructor."
+            )
+
+        # Serialize once: these exact bytes are what the server hashes against
+        # the JWT's body_sha256 claim, so they must match the wire body.
+        raw_body = request.model_dump_json(exclude_none=True)
+
+        if isinstance(self._client_auth, ConnectClientAuthWithSigner):
+            signed = self._client_auth.signer(raw_body)
+            jwt = await signed if inspect.isawaitable(signed) else signed
+        else:
+            jwt = sign_establish_client_jwt(self._client_auth, raw_body)
+
+        response = await self._client.post(
+            f"{self._base_url}/establish",
+            content=raw_body,
+            headers={**_JSON_HEADERS, "Authorization": f"{CLIENT_JWT_AUTH_SCHEME} {jwt}"},
+        )
+        return _handle(response, EstablishResponse)
+
+    async def status_poll(self, request: StatusPollRequest) -> StatusPollResponse:
+        return await self._post("/status-poll", request, StatusPollResponse)
+
+    async def redeem(self, request: RedeemRequest) -> RedeemResponse:
+        return await self._post("/redeem", request, RedeemResponse)
+
+    async def refresh(self, request: RefreshRequest) -> RefreshResponse:
+        return await self._post("/refresh", request, RefreshResponse)
+
+    async def info(self, request: InfoRequest) -> InfoResponse:
+        return await self._post("/info", request, InfoResponse)
+
+    async def get_application_public_key(
+        self,
+        application_anchor: str,
+        *,
+        force: bool = False,
+    ) -> str:
+        """Resolve (and cache) an application's PEM public key via ``/info``."""
+        if not force and application_anchor in self._public_key_cache:
+            return self._public_key_cache[application_anchor]
+        response = await self.info(
+            InfoRequest(applicationAnchor=application_anchor, locale=self._public_key_locale)
+        )
+        self._public_key_cache[application_anchor] = response.applicationPublicKey
+        return response.applicationPublicKey
+
+    def clear_public_key_cache(self, application_anchor: str | None = None) -> None:
+        if application_anchor is not None:
+            self._public_key_cache.pop(application_anchor, None)
+            return
+        self._public_key_cache.clear()
+
+    async def verify_access_token(self, jwt: str) -> AccessToken:
+        return await self._verifier.verify_access_token(jwt)
+
+    async def verify_refresh_token(self, jwt: str) -> RefreshToken:
+        return await self._verifier.verify_refresh_token(jwt)
+
+    async def _post(
+        self,
+        path: str,
+        request: BaseModel,
+        response_model: type[_ResponseT],
+    ) -> _ResponseT:
+        raw = request.model_dump_json(exclude_none=True)
+        response = await self._client.post(
+            f"{self._base_url}{path}", content=raw, headers=_JSON_HEADERS
+        )
+        return _handle(response, response_model)

--- a/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/client.py
+++ b/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/client.py
@@ -1,0 +1,181 @@
+"""Synchronous Connect API HTTP client."""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import TypeVar
+
+import httpx
+from pydantic import BaseModel
+from sudomimus_token import AccessToken, RefreshToken, TokenVerifier
+
+from ._generated.models import (
+    Error,
+    EstablishRequest,
+    EstablishResponse,
+    HealthResponse,
+    InfoRequest,
+    InfoResponse,
+    RedeemRequest,
+    RedeemResponse,
+    RefreshRequest,
+    RefreshResponse,
+    StatusPollRequest,
+    StatusPollResponse,
+)
+from .client_auth import (
+    ConnectClientAuth,
+    ConnectClientAuthWithSigner,
+    sign_establish_client_jwt,
+)
+from .constants import (
+    CLIENT_JWT_AUTH_SCHEME,
+    DEFAULT_PUBLIC_KEY_LOCALE,
+    PRODUCTION_BASE_URL,
+)
+from .errors import ConnectApiError, ConnectConfigError
+
+_ResponseT = TypeVar("_ResponseT", bound=BaseModel)
+
+_JSON_HEADERS = {"Content-Type": "application/json", "Accept": "application/json"}
+
+
+class ConnectClient:
+    """Client for the Sudomimus Connect API."""
+
+    def __init__(
+        self,
+        base_url: str = PRODUCTION_BASE_URL,
+        *,
+        http_client: httpx.Client | None = None,
+        public_key_fetch_locale: str = DEFAULT_PUBLIC_KEY_LOCALE,
+        client_auth: ConnectClientAuth | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = http_client if http_client is not None else httpx.Client()
+        self._owns_client = http_client is None
+        self._public_key_locale = public_key_fetch_locale
+        self._client_auth = client_auth
+        self._public_key_cache: dict[str, str] = {}
+        self._verifier = TokenVerifier(self.get_application_public_key)
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    def __enter__(self) -> ConnectClient:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying HTTP client if this instance created it."""
+        if self._owns_client:
+            self._client.close()
+
+    def health(self) -> HealthResponse:
+        response = self._client.get(
+            f"{self._base_url}/health", headers={"Accept": "application/json"}
+        )
+        return _handle(response, HealthResponse)
+
+    def establish(self, request: EstablishRequest) -> EstablishResponse:
+        if self._client_auth is None:
+            raise ConnectConfigError(
+                "ConnectClient.establish() requires client_auth. "
+                "Pass client_auth to the ConnectClient constructor."
+            )
+
+        # Serialize once: the exact bytes here are what the server hashes
+        # against the JWT's body_sha256 claim, so they must match the wire body.
+        raw_body = request.model_dump_json(exclude_none=True)
+
+        if isinstance(self._client_auth, ConnectClientAuthWithSigner):
+            jwt = self._client_auth.signer(raw_body)
+            if not isinstance(jwt, str):
+                raise ConnectConfigError(
+                    "client_auth.signer returned an awaitable; use AsyncConnectClient "
+                    "for async signers."
+                )
+        else:
+            jwt = sign_establish_client_jwt(self._client_auth, raw_body)
+
+        response = self._client.post(
+            f"{self._base_url}/establish",
+            content=raw_body,
+            headers={**_JSON_HEADERS, "Authorization": f"{CLIENT_JWT_AUTH_SCHEME} {jwt}"},
+        )
+        return _handle(response, EstablishResponse)
+
+    def status_poll(self, request: StatusPollRequest) -> StatusPollResponse:
+        return self._post("/status-poll", request, StatusPollResponse)
+
+    def redeem(self, request: RedeemRequest) -> RedeemResponse:
+        return self._post("/redeem", request, RedeemResponse)
+
+    def refresh(self, request: RefreshRequest) -> RefreshResponse:
+        return self._post("/refresh", request, RefreshResponse)
+
+    def info(self, request: InfoRequest) -> InfoResponse:
+        return self._post("/info", request, InfoResponse)
+
+    def get_application_public_key(
+        self,
+        application_anchor: str,
+        *,
+        force: bool = False,
+    ) -> str:
+        """Resolve (and cache) an application's PEM public key via ``/info``."""
+        if not force and application_anchor in self._public_key_cache:
+            return self._public_key_cache[application_anchor]
+        response = self.info(
+            InfoRequest(applicationAnchor=application_anchor, locale=self._public_key_locale)
+        )
+        self._public_key_cache[application_anchor] = response.applicationPublicKey
+        return response.applicationPublicKey
+
+    def clear_public_key_cache(self, application_anchor: str | None = None) -> None:
+        if application_anchor is not None:
+            self._public_key_cache.pop(application_anchor, None)
+            return
+        self._public_key_cache.clear()
+
+    def verify_access_token(self, jwt: str) -> AccessToken:
+        return self._verifier.verify_access_token(jwt)
+
+    def verify_refresh_token(self, jwt: str) -> RefreshToken:
+        return self._verifier.verify_refresh_token(jwt)
+
+    def _post(
+        self,
+        path: str,
+        request: BaseModel,
+        response_model: type[_ResponseT],
+    ) -> _ResponseT:
+        raw = request.model_dump_json(exclude_none=True)
+        response = self._client.post(
+            f"{self._base_url}{path}", content=raw, headers=_JSON_HEADERS
+        )
+        return _handle(response, response_model)
+
+
+def _handle(response: httpx.Response, response_model: type[_ResponseT]) -> _ResponseT:
+    if response.is_success:
+        return response_model.model_validate_json(response.content)
+    error = _try_read_error(response)
+    raise ConnectApiError(response.status_code, error.reason if error else None, error)
+
+
+def _try_read_error(response: httpx.Response) -> Error | None:
+    if not response.content:
+        return None
+    try:
+        return Error.model_validate_json(response.content)
+    except ValueError:
+        return None

--- a/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/client_auth.py
+++ b/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/client_auth.py
@@ -1,0 +1,105 @@
+"""Client-auth JWT signing for the Connect ``/establish`` endpoint.
+
+The server requires an ``Authorization: SudomimusClientJWT <jwt>`` header
+whose claims live in the JWT *body*: ``iss`` (the application anchor),
+``aud`` (``"sudomimus-connect"``), ``iat``, ``exp`` (lifetime at most 60s),
+a single-use ``jti``, and ``body_sha256`` — standard base64 of
+``SHA-256(rawHttpBody)`` over the exact UTF-8 bytes sent on the wire.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from sudomimus_token import create_jwt
+
+from .constants import (
+    CLIENT_JWT_AUDIENCE,
+    CLIENT_JWT_DEFAULT_LIFETIME_SECONDS,
+    CLIENT_JWT_MAX_LIFETIME_SECONDS,
+)
+from .errors import ConnectConfigError
+
+ClientAuthSigner = Callable[[str], str | Awaitable[str]]
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectClientAuthWithKey:
+    """Sign client-auth JWTs locally with a PEM-encoded RS256 private key."""
+
+    application_anchor: str
+    private_key_pem: str
+    lifetime_seconds: int | None = None
+    jti_generator: Callable[[], str] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectClientAuthWithSigner:
+    """Delegate client-auth JWT creation to a bring-your-own signer.
+
+    The signer receives the exact JSON string sent on the wire and MUST
+    return a signed JWT whose ``body_sha256`` claim is the standard base64 of
+    ``SHA-256(rawBody)``. The signer may be sync or (for the async client)
+    return an awaitable.
+    """
+
+    application_anchor: str
+    signer: ClientAuthSigner
+
+
+ConnectClientAuth = ConnectClientAuthWithKey | ConnectClientAuthWithSigner
+
+
+def sha256_base64(raw_body: str) -> str:
+    """Standard base64 of ``SHA-256(raw_body)`` over UTF-8 bytes."""
+    digest = hashlib.sha256(raw_body.encode("utf-8")).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+def build_establish_client_jwt_claims(
+    application_anchor: str,
+    raw_body: str,
+    *,
+    lifetime_seconds: int | None = None,
+    jti_generator: Callable[[], str] | None = None,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Build the client-auth JWT claim set without signing it."""
+    lifetime = (
+        lifetime_seconds
+        if lifetime_seconds is not None
+        else CLIENT_JWT_DEFAULT_LIFETIME_SECONDS
+    )
+    if lifetime <= 0 or lifetime > CLIENT_JWT_MAX_LIFETIME_SECONDS:
+        raise ConnectConfigError(
+            f"clientAuth.lifetime_seconds must be in (0, {CLIENT_JWT_MAX_LIFETIME_SECONDS}]; "
+            f"got {lifetime}"
+        )
+
+    iat = int(now if now is not None else time.time())
+    jti = jti_generator() if jti_generator is not None else str(uuid.uuid4())
+    return {
+        "iss": application_anchor,
+        "aud": CLIENT_JWT_AUDIENCE,
+        "iat": iat,
+        "exp": iat + lifetime,
+        "jti": jti,
+        "body_sha256": sha256_base64(raw_body),
+    }
+
+
+def sign_establish_client_jwt(config: ConnectClientAuthWithKey, raw_body: str) -> str:
+    """Sign a client-auth JWT (claims in the body, empty header) with RS256."""
+    claims = build_establish_client_jwt_claims(
+        config.application_anchor,
+        raw_body,
+        lifetime_seconds=config.lifetime_seconds,
+        jti_generator=config.jti_generator,
+    )
+    return create_jwt({}, claims, config.private_key_pem)

--- a/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/constants.py
+++ b/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/constants.py
@@ -1,0 +1,12 @@
+"""Connect client constants."""
+
+from __future__ import annotations
+
+PRODUCTION_BASE_URL = "https://connect-api.sudomimus.com"
+
+DEFAULT_PUBLIC_KEY_LOCALE = "en-US"
+
+CLIENT_JWT_AUDIENCE = "sudomimus-connect"
+CLIENT_JWT_AUTH_SCHEME = "SudomimusClientJWT"
+CLIENT_JWT_DEFAULT_LIFETIME_SECONDS = 30
+CLIENT_JWT_MAX_LIFETIME_SECONDS = 60

--- a/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/errors.py
+++ b/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/errors.py
@@ -1,0 +1,26 @@
+"""Connect API error types."""
+
+from __future__ import annotations
+
+from ._generated.models import Error
+
+
+class ConnectApiError(Exception):
+    """Raised for any non-2xx response from the Connect API.
+
+    For ``PRIVATE`` reasons the server returns an empty body, so
+    :attr:`reason` is ``None`` and only :attr:`status` carries signal.
+    """
+
+    def __init__(self, status: int, reason: str | None, body: Error | None) -> None:
+        message = (
+            f"Connect API error {status}: {reason}" if reason else f"Connect API error {status}"
+        )
+        super().__init__(message)
+        self.status = status
+        self.reason = reason
+        self.body = body
+
+
+class ConnectConfigError(Exception):
+    """Raised for client-side misconfiguration (e.g. missing client-auth)."""

--- a/sdks/python/packages/sudomimus-connect/tests/test_smoke.py
+++ b/sdks/python/packages/sudomimus-connect/tests/test_smoke.py
@@ -1,18 +1,260 @@
-"""Smoke tests for sudomimus_connect."""
+"""Tests for sudomimus_connect."""
 
 from __future__ import annotations
 
-from sudomimus_connect import ConnectClient, EstablishRequest
+import asyncio
+import json
+import time
+from collections.abc import Callable
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from sudomimus_connect import (
+    PRODUCTION_BASE_URL,
+    AsyncConnectClient,
+    ConnectApiError,
+    ConnectClient,
+    ConnectClientAuthWithKey,
+    ConnectClientAuthWithSigner,
+    ConnectConfigError,
+    EstablishRequest,
+    RedeemRequest,
+    RefreshRequest,
+    StatusPollRequest,
+    sha256_base64,
+)
+from sudomimus_token import create_jwt, decode_base64url
+
+Handler = Callable[[httpx.Request], httpx.Response]
 
 
-def test_client_normalizes_base_url() -> None:
-    client = ConnectClient(base_url="https://connect.example.com/")
-    assert client.base_url == "https://connect.example.com"
+def _keypair() -> tuple[str, str]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+    public_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("ascii")
+    return private_pem, public_pem
 
 
-def test_generated_model_round_trip() -> None:
-    request = EstablishRequest(
-        applicationKey="app-key",
-        redirectUri="https://example.com/cb",
+def _client(handler: Handler, **kwargs: object) -> ConnectClient:
+    transport = httpx.MockTransport(handler)
+    return ConnectClient(http_client=httpx.Client(transport=transport), **kwargs)  # type: ignore[arg-type]
+
+
+def test_base_url_normalized() -> None:
+    assert ConnectClient(base_url="https://connect.example.com/").base_url == (
+        "https://connect.example.com"
     )
-    assert request.applicationKey == "app-key"
+
+
+def test_default_base_url_is_production() -> None:
+    assert ConnectClient().base_url == PRODUCTION_BASE_URL
+
+
+def test_establish_requires_client_auth() -> None:
+    with _client(lambda r: httpx.Response(200)) as client, pytest.raises(ConnectConfigError):
+        client.establish(EstablishRequest(applicationAnchor="my-app"))
+
+
+def test_establish_signs_request_with_matching_body_hash() -> None:
+    private_pem, _ = _keypair()
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["auth"] = request.headers["Authorization"]
+        captured["raw"] = request.content.decode("utf-8")
+        return httpx.Response(
+            200,
+            json={
+                "applicationAnchor": "my-app",
+                "exposureKey": "ek",
+                "hiddenKey": "hk",
+            },
+        )
+
+    auth = ConnectClientAuthWithKey(application_anchor="my-app", private_key_pem=private_pem)
+    with _client(handler, client_auth=auth) as client:
+        result = client.establish(EstablishRequest(applicationAnchor="my-app"))
+
+    assert result.exposureKey == "ek"
+    scheme, _, jwt = captured["auth"].partition(" ")
+    assert scheme == "SudomimusClientJWT"
+    claims = json.loads(decode_base64url(jwt.split(".")[1]))
+    assert claims["iss"] == "my-app"
+    assert claims["aud"] == "sudomimus-connect"
+    assert claims["exp"] - claims["iat"] == 30
+    assert claims["body_sha256"] == sha256_base64(captured["raw"])
+
+
+def test_establish_with_byo_signer() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "SudomimusClientJWT fixed.jwt.value"
+        return httpx.Response(
+            200,
+            json={"applicationAnchor": "my-app", "exposureKey": "ek", "hiddenKey": "hk"},
+        )
+
+    auth = ConnectClientAuthWithSigner(
+        application_anchor="my-app", signer=lambda _raw: "fixed.jwt.value"
+    )
+    with _client(handler, client_auth=auth) as client:
+        client.establish(EstablishRequest(applicationAnchor="my-app"))
+
+
+def test_status_poll_realized_variant() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"status": "REALIZED", "confirmationKey": "ck"})
+
+    with _client(handler) as client:
+        result = client.status_poll(StatusPollRequest(exposureKey="ek", hiddenKey="hk"))
+    assert result.root.status == "REALIZED"
+    assert result.root.confirmationKey == "ck"
+
+
+def test_redeem_happy_path() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "applicationAnchor": "my-app",
+                "refreshToken": "r.t",
+                "accessToken": "a.t",
+            },
+        )
+
+    with _client(handler) as client:
+        result = client.redeem(
+            RedeemRequest(exposureKey="ek", hiddenKey="hk", confirmationKey="ck")
+        )
+    assert result.accessToken == "a.t"
+
+
+def test_error_with_reason() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"reason": "ClientJwtInvalid"})
+
+    auth = ConnectClientAuthWithSigner(application_anchor="my-app", signer=lambda _: "x.y.z")
+    with _client(handler, client_auth=auth) as client, pytest.raises(ConnectApiError) as exc:
+        client.establish(EstablishRequest(applicationAnchor="my-app"))
+    assert exc.value.status == 401
+    assert exc.value.reason == "ClientJwtInvalid"
+
+
+def test_error_with_empty_body() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, content=b"")
+
+    with _client(handler) as client, pytest.raises(ConnectApiError) as exc:
+        client.refresh(RefreshRequest(refreshToken="r.t"))
+    assert exc.value.reason is None
+
+
+def test_get_application_public_key_caches() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(
+            200,
+            json={
+                "applicationAnchor": "my-app",
+                "applicationName": "My App",
+                "applicationPublicKey": "PEM",
+            },
+        )
+
+    with _client(handler) as client:
+        assert client.get_application_public_key("my-app") == "PEM"
+        assert client.get_application_public_key("my-app") == "PEM"
+        assert calls["n"] == 1
+        assert client.get_application_public_key("my-app", force=True) == "PEM"
+        assert calls["n"] == 2
+        client.clear_public_key_cache("my-app")
+        client.get_application_public_key("my-app")
+        assert calls["n"] == 3
+
+
+def test_verify_access_token_end_to_end() -> None:
+    private_pem, public_pem = _keypair()
+    jwt = create_jwt(
+        {"kty": "Access", "aud": "my-app", "iat": int(time.time()), "exp": int(time.time()) + 60},
+        {"accountIdentifier": "acct-1", "firstName": "Ada"},
+        private_pem,
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "applicationAnchor": "my-app",
+                "applicationName": "My App",
+                "applicationPublicKey": public_pem,
+            },
+        )
+
+    with _client(handler) as client:
+        token = client.verify_access_token(jwt)
+    assert token.body.accountIdentifier == "acct-1"
+
+
+def test_async_redeem_and_info() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/info":
+            return httpx.Response(
+                200,
+                json={
+                    "applicationAnchor": "my-app",
+                    "applicationName": "My App",
+                    "applicationPublicKey": "PEM",
+                },
+            )
+        return httpx.Response(
+            200,
+            json={"applicationAnchor": "my-app", "refreshToken": "r.t", "accessToken": "a.t"},
+        )
+
+    async def run() -> tuple[str, str]:
+        async with AsyncConnectClient(
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        ) as client:
+            redeemed = await client.redeem(
+                RedeemRequest(exposureKey="ek", hiddenKey="hk", confirmationKey="ck")
+            )
+            key = await client.get_application_public_key("my-app")
+            return redeemed.accessToken, key
+
+    access_token, public_key = asyncio.run(run())
+    assert access_token == "a.t"
+    assert public_key == "PEM"
+
+
+def test_async_establish_with_async_signer() -> None:
+    async def signer(_raw: str) -> str:
+        return "async.signed.jwt"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "SudomimusClientJWT async.signed.jwt"
+        return httpx.Response(
+            200,
+            json={"applicationAnchor": "my-app", "exposureKey": "ek", "hiddenKey": "hk"},
+        )
+
+    auth = ConnectClientAuthWithSigner(application_anchor="my-app", signer=signer)
+
+    async def run() -> str:
+        async with AsyncConnectClient(
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            client_auth=auth,
+        ) as client:
+            result = await client.establish(EstablishRequest(applicationAnchor="my-app"))
+            return result.exposureKey
+
+    assert asyncio.run(run()) == "ek"

--- a/sdks/python/packages/sudomimus-native/README.md
+++ b/sdks/python/packages/sudomimus-native/README.md
@@ -1,6 +1,9 @@
 # sudomimus-native
 
-Python SDK for the Sudomimus Native API — the public gateway used by native clients (desktop applications, games) to authenticate through an external browser.
+Python SDK for the Sudomimus Native API — the direct-issue gateway for
+native callers (desktop applications, games, headless processes). Exchange a
+Steam Web API auth ticket or an access-key credential for application access
+and refresh tokens in a single round trip.
 
 ## Install
 
@@ -11,20 +14,50 @@ pip install sudomimus-native
 ## Usage
 
 ```python
-from sudomimus_native import NativeClient
+from sudomimus_native import NativeClient, DirectIssueSteamTicketRequest
 
-client = NativeClient(base_url="https://native.sudomimus.com")
+with NativeClient() as client:
+    tokens = client.direct_issue_steam_ticket(
+        DirectIssueSteamTicketRequest(
+            applicationAnchor="my-app",
+            steamTicketHex="...",  # from GetAuthTicketForWebApi("sudomimus")
+            steamAppId=480,
+        )
+    )
+    print(tokens.accessToken, tokens.refreshToken)
 ```
+
+Access-key credentials (issued in the admin console for headless callers):
+
+```python
+from sudomimus_native import DirectIssueAccessKeyRequest
+
+tokens = client.direct_issue_access_key(
+    DirectIssueAccessKeyRequest(
+        applicationAnchor="my-app",
+        accessKeyIdentifier="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        accessKeySecret="<64 hex chars>",
+    )
+)
+```
+
+An `AsyncNativeClient` with the same methods is available for `asyncio`
+callers. Non-2xx responses raise `NativeApiError` (inspect `.status` and
+`.reason`). Issued tokens are opaque to this SDK; verify them with
+[`sudomimus-token`](../sudomimus-token).
 
 ## Models
 
-Pydantic v2 models are generated from [`specs/native.yaml`](../../../../specs/native.yaml) and re-exported from the package root:
+Pydantic v2 models are generated from [`specs/native.yaml`](../../../../specs/native.yaml)
+and re-exported from the package root:
 
 ```python
 from sudomimus_native import (
+    DirectIssueAccessKeyRequest,
+    DirectIssueAccessKeyResponse,
+    DirectIssueSteamTicketRequest,
+    DirectIssueSteamTicketResponse,
     NativeError,
-    StatusPollRequest,
-    StatusPollResponse,
 )
 ```
 

--- a/sdks/python/packages/sudomimus-native/src/sudomimus_native/__init__.py
+++ b/sdks/python/packages/sudomimus-native/src/sudomimus_native/__init__.py
@@ -1,48 +1,33 @@
 """Sudomimus Native SDK.
 
-Native client entry point for the Sudomimus authentication platform.
+Direct-issue client for native callers: exchange a Steam Web API auth ticket
+or an access-key credential for application access and refresh tokens in a
+single round trip.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-import httpx
-
 from ._generated.models import (
-    Error as NativeError,
+    DirectIssueAccessKeyRequest,
+    DirectIssueAccessKeyResponse,
+    DirectIssueSteamTicketRequest,
+    DirectIssueSteamTicketResponse,
 )
-from ._generated.models import (
-    StatusPollRequest,
-    StatusPollResponse,
-)
+from ._generated.models import Error as NativeError
+from .async_client import AsyncNativeClient
+from .client import NativeClient
+from .constants import PRODUCTION_BASE_URL, STEAM_TICKET_IDENTITY
+from .errors import NativeApiError
 
 __all__ = [
+    "PRODUCTION_BASE_URL",
+    "STEAM_TICKET_IDENTITY",
+    "AsyncNativeClient",
+    "DirectIssueAccessKeyRequest",
+    "DirectIssueAccessKeyResponse",
+    "DirectIssueSteamTicketRequest",
+    "DirectIssueSteamTicketResponse",
+    "NativeApiError",
     "NativeClient",
-    "NativeClientOptions",
     "NativeError",
-    "StatusPollRequest",
-    "StatusPollResponse",
 ]
-
-
-@dataclass(slots=True)
-class NativeClientOptions:
-    base_url: str
-
-
-class NativeClient:
-    """Client for the Sudomimus Native API."""
-
-    def __init__(
-        self,
-        *,
-        base_url: str,
-        transport: httpx.Client | None = None,
-    ) -> None:
-        self._base_url = base_url.rstrip("/")
-        self._transport = transport
-
-    @property
-    def base_url(self) -> str:
-        return self._base_url

--- a/sdks/python/packages/sudomimus-native/src/sudomimus_native/_generated/models.py
+++ b/sdks/python/packages/sudomimus-native/src/sudomimus_native/_generated/models.py
@@ -3,45 +3,69 @@
 
 from __future__ import annotations
 
-from enum import StrEnum
-
 from pydantic import BaseModel, Field
 
 
-class StatusPollRequest(BaseModel):
-    pollToken: str = Field(
-        ..., description="Opaque token issued when the flow was initiated."
+class DirectIssueAccessKeyRequest(BaseModel):
+    applicationAnchor: str = Field(
+        ..., description="Public anchor identifying the integrating application."
+    )
+    accessKeyIdentifier: str = Field(
+        ...,
+        description="UUID v4 string identifying the access-key credential.\nFormat: `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.\n",
+    )
+    accessKeySecret: str = Field(
+        ...,
+        description="64-char lowercase hex string (32 random bytes) returned exactly\nonce when the access key was issued. Never logged or persisted\nin plaintext server-side after creation.\n",
     )
 
 
-class Status(StrEnum):
-    """
-    Current status of the authentication flow.
-    """
-
-    PENDING = "PENDING"
-    APPROVED = "APPROVED"
-    DENIED = "DENIED"
-    EXPIRED = "EXPIRED"
-
-
-class StatusPollResponse(BaseModel):
-    status: Status = Field(
-        ..., description="Current status of the authentication flow."
+class DirectIssueAccessKeyResponse(BaseModel):
+    applicationAnchor: str
+    accessToken: str = Field(
+        ...,
+        description="Short-lived access token (JWT). Body shape matches the Connect SDK's access token.",
     )
-    accessToken: str | None = Field(
-        None,
-        description="Application access token; present only when status is APPROVED.",
+    refreshToken: str = Field(
+        ...,
+        description="Long-lived refresh token (JWT). Use Connect's `/refresh` for renewal without re-presenting the access key.",
     )
-    refreshToken: str | None = Field(
-        None,
-        description="Application refresh token; present only when status is APPROVED.",
+
+
+class DirectIssueSteamTicketRequest(BaseModel):
+    applicationAnchor: str = Field(
+        ..., description="Public anchor identifying the integrating application."
+    )
+    steamTicketHex: str = Field(
+        ...,
+        description='Hex-encoded Steam Web API auth ticket bytes returned from\n`ISteamUser::GetAuthTicketForWebApi("sudomimus")`. Case\ninsensitive — the server lowercases before hashing for replay\nprotection, but forwards the original bytes to Steam.\n',
+    )
+    steamAppId: int = Field(
+        ...,
+        description="Steam App ID under which the ticket was generated. Must be\nallow-listed by the application's `STEAM_TICKET` authentication\nrule. Tickets are bound to their issuing App ID server-side;\npassing a different value will fail Steam verification.\n",
+        ge=1,
+    )
+
+
+class DirectIssueSteamTicketResponse(BaseModel):
+    applicationAnchor: str
+    accessToken: str = Field(
+        ...,
+        description="Short-lived access token (JWT). Body shape matches the Connect SDK's access token.",
+    )
+    refreshToken: str = Field(
+        ...,
+        description="Long-lived refresh token (JWT). Use Connect's `/refresh` to obtain a new access token without re-acquiring a Steam ticket.",
     )
 
 
 class Error(BaseModel):
-    code: str = Field(..., description="Stable machine-readable error code.")
-    message: str = Field(..., description="Human-readable error message.")
-    requestId: str | None = Field(
-        None, description="Identifier for correlating with platform logs."
-    )
+    """
+    Error response body. The Native service emits `{ "reason": "<SymbolDescription>" }`
+    for known failure modes. When the reason symbol's description begins with
+    `PRIVATE`, the body is empty (zero bytes) and only the HTTP status carries
+    signal — both `reason` and the body itself are absent in that case.
+
+    """
+
+    reason: str | None = Field(None, description="Stable machine-readable reason code.")

--- a/sdks/python/packages/sudomimus-native/src/sudomimus_native/async_client.py
+++ b/sdks/python/packages/sudomimus-native/src/sudomimus_native/async_client.py
@@ -1,0 +1,83 @@
+"""Asynchronous Native API HTTP client."""
+
+from __future__ import annotations
+
+from types import TracebackType
+
+import httpx
+from pydantic import BaseModel
+
+from ._generated.models import (
+    DirectIssueAccessKeyRequest,
+    DirectIssueAccessKeyResponse,
+    DirectIssueSteamTicketRequest,
+    DirectIssueSteamTicketResponse,
+)
+from .client import _JSON_HEADERS, _handle, _ResponseT
+from .constants import PRODUCTION_BASE_URL
+
+
+class AsyncNativeClient:
+    """Async client for the Sudomimus Native API."""
+
+    def __init__(
+        self,
+        base_url: str = PRODUCTION_BASE_URL,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = http_client if http_client is not None else httpx.AsyncClient()
+        self._owns_client = http_client is None
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    async def __aenter__(self) -> AsyncNativeClient:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client if this instance created it."""
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def direct_issue_steam_ticket(
+        self,
+        request: DirectIssueSteamTicketRequest,
+    ) -> DirectIssueSteamTicketResponse:
+        """Exchange a Steam Web API auth ticket for application tokens."""
+        return await self._post(
+            "/direct-issue/steam-ticket", request, DirectIssueSteamTicketResponse
+        )
+
+    async def direct_issue_access_key(
+        self,
+        request: DirectIssueAccessKeyRequest,
+    ) -> DirectIssueAccessKeyResponse:
+        """Exchange an access-key credential for application tokens."""
+        return await self._post(
+            "/direct-issue/access-key", request, DirectIssueAccessKeyResponse
+        )
+
+    async def _post(
+        self,
+        path: str,
+        request: BaseModel,
+        response_model: type[_ResponseT],
+    ) -> _ResponseT:
+        raw = request.model_dump_json(exclude_none=True)
+        response = await self._client.post(
+            f"{self._base_url}{path}",
+            content=raw,
+            headers=_JSON_HEADERS,
+        )
+        return _handle(response, response_model)

--- a/sdks/python/packages/sudomimus-native/src/sudomimus_native/client.py
+++ b/sdks/python/packages/sudomimus-native/src/sudomimus_native/client.py
@@ -1,0 +1,109 @@
+"""Synchronous Native API HTTP client."""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import TypeVar
+
+import httpx
+from pydantic import BaseModel
+
+from ._generated.models import (
+    DirectIssueAccessKeyRequest,
+    DirectIssueAccessKeyResponse,
+    DirectIssueSteamTicketRequest,
+    DirectIssueSteamTicketResponse,
+    Error,
+)
+from .constants import PRODUCTION_BASE_URL
+from .errors import NativeApiError
+
+_ResponseT = TypeVar("_ResponseT", bound=BaseModel)
+
+_JSON_HEADERS = {"Content-Type": "application/json", "Accept": "application/json"}
+
+
+class NativeClient:
+    """Client for the Sudomimus Native API.
+
+    The Native API is unauthenticated at the transport layer — the Steam
+    ticket or access-key credential in the request body is the credential.
+    """
+
+    def __init__(
+        self,
+        base_url: str = PRODUCTION_BASE_URL,
+        *,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = http_client if http_client is not None else httpx.Client()
+        self._owns_client = http_client is None
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    def __enter__(self) -> NativeClient:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying HTTP client if this instance created it."""
+        if self._owns_client:
+            self._client.close()
+
+    def direct_issue_steam_ticket(
+        self,
+        request: DirectIssueSteamTicketRequest,
+    ) -> DirectIssueSteamTicketResponse:
+        """Exchange a Steam Web API auth ticket for application tokens."""
+        return self._post(
+            "/direct-issue/steam-ticket", request, DirectIssueSteamTicketResponse
+        )
+
+    def direct_issue_access_key(
+        self,
+        request: DirectIssueAccessKeyRequest,
+    ) -> DirectIssueAccessKeyResponse:
+        """Exchange an access-key credential for application tokens."""
+        return self._post(
+            "/direct-issue/access-key", request, DirectIssueAccessKeyResponse
+        )
+
+    def _post(
+        self,
+        path: str,
+        request: BaseModel,
+        response_model: type[_ResponseT],
+    ) -> _ResponseT:
+        raw = request.model_dump_json(exclude_none=True)
+        response = self._client.post(
+            f"{self._base_url}{path}",
+            content=raw,
+            headers=_JSON_HEADERS,
+        )
+        return _handle(response, response_model)
+
+
+def _handle(response: httpx.Response, response_model: type[_ResponseT]) -> _ResponseT:
+    if response.is_success:
+        return response_model.model_validate_json(response.content)
+    error = _try_read_error(response)
+    raise NativeApiError(response.status_code, error.reason if error else None, error)
+
+
+def _try_read_error(response: httpx.Response) -> Error | None:
+    if not response.content:
+        return None
+    try:
+        return Error.model_validate_json(response.content)
+    except ValueError:
+        return None

--- a/sdks/python/packages/sudomimus-native/src/sudomimus_native/constants.py
+++ b/sdks/python/packages/sudomimus-native/src/sudomimus_native/constants.py
@@ -1,0 +1,11 @@
+"""Native client constants."""
+
+from __future__ import annotations
+
+PRODUCTION_BASE_URL = "https://native-api.sudomimus.com"
+
+# Identity string the client SDK MUST pass to
+# ``ISteamUser::GetAuthTicketForWebApi(identity)``. Steam binds the issued
+# ticket to this identity and the Native API verifier hardcodes the same
+# value, so tickets generated with any other identity are rejected.
+STEAM_TICKET_IDENTITY = "sudomimus"

--- a/sdks/python/packages/sudomimus-native/src/sudomimus_native/errors.py
+++ b/sdks/python/packages/sudomimus-native/src/sudomimus_native/errors.py
@@ -1,0 +1,22 @@
+"""Native API error type."""
+
+from __future__ import annotations
+
+from ._generated.models import Error
+
+
+class NativeApiError(Exception):
+    """Raised for any non-2xx response from the Native API.
+
+    Distinguish failure modes by :attr:`status` and :attr:`reason`. All
+    access-key credential failures collapse into a single opaque
+    ``AccessKeyDirectDenied`` 401 reason; Steam-ticket replays surface as 409.
+    For ``PRIVATE`` reasons the body is empty and :attr:`reason` is ``None``.
+    """
+
+    def __init__(self, status: int, reason: str | None, body: Error | None) -> None:
+        message = f"Native API error {status}: {reason}" if reason else f"Native API error {status}"
+        super().__init__(message)
+        self.status = status
+        self.reason = reason
+        self.body = body

--- a/sdks/python/packages/sudomimus-native/tests/test_smoke.py
+++ b/sdks/python/packages/sudomimus-native/tests/test_smoke.py
@@ -1,15 +1,126 @@
-"""Smoke tests for sudomimus_native."""
+"""Tests for sudomimus_native."""
 
 from __future__ import annotations
 
-from sudomimus_native import NativeClient, StatusPollRequest
+import asyncio
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+from sudomimus_native import (
+    PRODUCTION_BASE_URL,
+    AsyncNativeClient,
+    DirectIssueAccessKeyRequest,
+    DirectIssueSteamTicketRequest,
+    NativeApiError,
+    NativeClient,
+)
+
+Handler = Callable[[httpx.Request], httpx.Response]
 
 
-def test_client_normalizes_base_url() -> None:
+def _client(handler: Handler) -> NativeClient:
+    return NativeClient(http_client=httpx.Client(transport=httpx.MockTransport(handler)))
+
+
+def _token_response(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "applicationAnchor": "my-app",
+            "accessToken": "a.b.c",
+            "refreshToken": "d.e.f",
+        },
+    )
+
+
+def test_base_url_normalized() -> None:
     client = NativeClient(base_url="https://native.example.com/")
     assert client.base_url == "https://native.example.com"
 
 
-def test_generated_model_round_trip() -> None:
-    request = StatusPollRequest(pollToken="poll-token")
-    assert request.pollToken == "poll-token"
+def test_default_base_url_is_production() -> None:
+    assert NativeClient().base_url == PRODUCTION_BASE_URL
+
+
+def test_direct_issue_steam_ticket() -> None:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return _token_response(request)
+
+    with _client(handler) as client:
+        result = client.direct_issue_steam_ticket(
+            DirectIssueSteamTicketRequest(
+                applicationAnchor="my-app", steamTicketHex="deadbeef", steamAppId=480
+            )
+        )
+
+    assert captured["url"].endswith("/direct-issue/steam-ticket")
+    assert captured["body"] == {
+        "applicationAnchor": "my-app",
+        "steamTicketHex": "deadbeef",
+        "steamAppId": 480,
+    }
+    assert result.accessToken == "a.b.c"
+    assert result.refreshToken == "d.e.f"
+
+
+def test_direct_issue_access_key() -> None:
+    with _client(_token_response) as client:
+        result = client.direct_issue_access_key(
+            DirectIssueAccessKeyRequest(
+                applicationAnchor="my-app",
+                accessKeyIdentifier="11111111-1111-4111-8111-111111111111",
+                accessKeySecret="0" * 64,
+            )
+        )
+    assert result.accessToken == "a.b.c"
+
+
+def test_error_with_reason() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"reason": "AccessKeyDirectDenied"})
+
+    with _client(handler) as client, pytest.raises(NativeApiError) as exc:
+        client.direct_issue_access_key(
+            DirectIssueAccessKeyRequest(
+                applicationAnchor="my-app",
+                accessKeyIdentifier="11111111-1111-4111-8111-111111111111",
+                accessKeySecret="0" * 64,
+            )
+        )
+    assert exc.value.status == 401
+    assert exc.value.reason == "AccessKeyDirectDenied"
+
+
+def test_error_with_empty_body() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, content=b"")
+
+    with _client(handler) as client, pytest.raises(NativeApiError) as exc:
+        client.direct_issue_steam_ticket(
+            DirectIssueSteamTicketRequest(
+                applicationAnchor="my-app", steamTicketHex="ab", steamAppId=1
+            )
+        )
+    assert exc.value.status == 403
+    assert exc.value.reason is None
+
+
+def test_async_direct_issue_steam_ticket() -> None:
+    async def run() -> str:
+        async with AsyncNativeClient(
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(_token_response))
+        ) as client:
+            result = await client.direct_issue_steam_ticket(
+                DirectIssueSteamTicketRequest(
+                    applicationAnchor="my-app", steamTicketHex="ab", steamAppId=1
+                )
+            )
+            return result.accessToken
+
+    assert asyncio.run(run()) == "a.b.c"

--- a/sdks/python/packages/sudomimus-token/README.md
+++ b/sdks/python/packages/sudomimus-token/README.md
@@ -1,0 +1,49 @@
+# sudomimus-token
+
+Python SDK for parsing and verifying Sudomimus access and refresh JWTs.
+
+Sudomimus tokens carry the standard envelope claims (`iss`, `aud`, `iat`,
+`exp`, `jti`, `kty`) in the JWT **header**; the body holds only the
+application-specific claims. The verifier checks structure, key type,
+audience, expiration, and the RS256 signature against an application public
+key you resolve (typically via the Connect `/info` endpoint).
+
+## Install
+
+```bash
+pip install sudomimus-token
+```
+
+## Usage
+
+```python
+from sudomimus_token import TokenVerifier
+
+def resolve_public_key(application_anchor: str) -> str:
+    # Fetch the application's PEM public key (e.g. from Connect /info).
+    ...
+
+verifier = TokenVerifier(resolve_public_key)
+access = verifier.verify_access_token(jwt)
+print(access.body.accountIdentifier, access.header.aud)
+```
+
+Async callers use `AsyncTokenVerifier` with an awaitable resolver:
+
+```python
+from sudomimus_token import AsyncTokenVerifier
+
+verifier = AsyncTokenVerifier(resolve_public_key_async)
+access = await verifier.verify_access_token(jwt)
+```
+
+Verification failures raise `TokenError` with a `code` drawn from
+`TokenErrorCode` (`INVALID_JWT`, `WRONG_KEY_TYPE`, `MISSING_AUDIENCE`,
+`EXPIRED`, `INVALID_SIGNATURE`).
+
+For read-only inspection without trust decisions, use `parse_access_token`,
+`parse_refresh_token`, or `peek_header`.
+
+## License
+
+[MIT](../../../../LICENSE)

--- a/sdks/python/packages/sudomimus-token/pyproject.toml
+++ b/sdks/python/packages/sudomimus-token/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "sudomimus-connect"
+name = "sudomimus-token"
 version = "0.0.1"
-description = "Sudomimus Connect SDK — token exchange (Establish, Redeem, Refresh)."
+description = "Sudomimus Token SDK — parse and verify Sudomimus access and refresh JWTs."
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
@@ -9,9 +9,8 @@ authors = [
     { name = "Sudomimus Contributors" },
 ]
 dependencies = [
-    "httpx>=0.27",
+    "cryptography>=42",
     "pydantic>=2.7",
-    "sudomimus-token",
 ]
 
 [project.urls]
@@ -23,4 +22,4 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/sudomimus_connect"]
+packages = ["src/sudomimus_token"]

--- a/sdks/python/packages/sudomimus-token/src/sudomimus_token/__init__.py
+++ b/sdks/python/packages/sudomimus-token/src/sudomimus_token/__init__.py
@@ -1,0 +1,47 @@
+"""Sudomimus Token SDK.
+
+Parse and verify Sudomimus access and refresh JWTs. Verification covers
+structural integrity, expected key type (``kty``), audience presence,
+expiration, and the RS256 signature against a caller-supplied public key.
+"""
+
+from __future__ import annotations
+
+from ._codec import create_jwt, decode_base64url, encode_base64url, sign_rs256, verify_rs256
+from .errors import TokenError, TokenErrorCode
+from .models import AccessTokenBody, JwtHeader, RefreshTokenBody
+from .parser import parse_access_token, parse_refresh_token, peek_header
+from .token import AccessToken, JwtToken, RefreshToken
+from .verifier import (
+    ACCESS_TOKEN_KEY_TYPE,
+    REFRESH_TOKEN_KEY_TYPE,
+    AsyncPublicKeyResolver,
+    AsyncTokenVerifier,
+    PublicKeyResolver,
+    TokenVerifier,
+)
+
+__all__ = [
+    "ACCESS_TOKEN_KEY_TYPE",
+    "REFRESH_TOKEN_KEY_TYPE",
+    "AccessToken",
+    "AccessTokenBody",
+    "AsyncPublicKeyResolver",
+    "AsyncTokenVerifier",
+    "JwtHeader",
+    "JwtToken",
+    "PublicKeyResolver",
+    "RefreshToken",
+    "RefreshTokenBody",
+    "TokenError",
+    "TokenErrorCode",
+    "TokenVerifier",
+    "create_jwt",
+    "decode_base64url",
+    "encode_base64url",
+    "parse_access_token",
+    "parse_refresh_token",
+    "peek_header",
+    "sign_rs256",
+    "verify_rs256",
+]

--- a/sdks/python/packages/sudomimus-token/src/sudomimus_token/_codec.py
+++ b/sdks/python/packages/sudomimus-token/src/sudomimus_token/_codec.py
@@ -1,0 +1,77 @@
+"""Low-level JWT codec: base64url, JSON segments, and RS256 sign/verify.
+
+Sudomimus JWTs follow the on-wire layout used by ``@sudoo/jwt``: three
+base64url segments (no padding) joined by dots, where the signing input is
+the literal ``headerSegment.bodySegment`` string (UTF-8). Standard envelope
+claims live in the header segment, not the body.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
+
+
+def decode_base64url(segment: str) -> bytes:
+    """Decode a base64url segment, tolerating missing padding."""
+    padding_len = (-len(segment)) % 4
+    return base64.urlsafe_b64decode(segment + ("=" * padding_len))
+
+
+def encode_base64url(data: bytes) -> str:
+    """Encode bytes as base64url without padding."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _json_segment_bytes(value: dict[str, Any]) -> bytes:
+    return json.dumps(value, separators=(",", ":")).encode("utf-8")
+
+
+def verify_rs256(public_key_pem: str, signing_input: bytes, signature: bytes) -> bool:
+    """Verify an RS256 signature against a PEM-encoded RSA public key.
+
+    Returns ``False`` for a signature mismatch or a non-RSA key (which can
+    never produce a valid RS256 signature).
+    """
+    public_key = serialization.load_pem_public_key(public_key_pem.encode("utf-8"))
+    if not isinstance(public_key, RSAPublicKey):
+        return False
+    try:
+        public_key.verify(signature, signing_input, padding.PKCS1v15(), hashes.SHA256())
+        return True
+    except InvalidSignature:
+        return False
+
+
+def sign_rs256(private_key_pem: str, signing_input: bytes) -> bytes:
+    """Produce an RS256 signature with a PEM-encoded RSA private key."""
+    private_key = serialization.load_pem_private_key(
+        private_key_pem.encode("utf-8"),
+        password=None,
+    )
+    if not isinstance(private_key, RSAPrivateKey):
+        raise ValueError("client-auth private key must be an RSA private key for RS256.")
+    return private_key.sign(signing_input, padding.PKCS1v15(), hashes.SHA256())
+
+
+def create_jwt(
+    header: dict[str, Any],
+    body: dict[str, Any],
+    private_key_pem: str,
+) -> str:
+    """Build a signed compact JWT from header/body claim dicts.
+
+    Mirrors ``@sudoo/jwt``'s creator: each segment is base64url of its JSON,
+    and the signature signs the literal ``headerSegment.bodySegment`` bytes.
+    """
+    header_segment = encode_base64url(_json_segment_bytes(header))
+    body_segment = encode_base64url(_json_segment_bytes(body))
+    signing_input = f"{header_segment}.{body_segment}".encode("ascii")
+    signature_segment = encode_base64url(sign_rs256(private_key_pem, signing_input))
+    return f"{header_segment}.{body_segment}.{signature_segment}"

--- a/sdks/python/packages/sudomimus-token/src/sudomimus_token/errors.py
+++ b/sdks/python/packages/sudomimus-token/src/sudomimus_token/errors.py
@@ -1,0 +1,23 @@
+"""Token parse/verify error types."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class TokenErrorCode(StrEnum):
+    """Categorical reason a token failed to parse or verify."""
+
+    INVALID_JWT = "INVALID_JWT"
+    WRONG_KEY_TYPE = "WRONG_KEY_TYPE"
+    MISSING_AUDIENCE = "MISSING_AUDIENCE"
+    EXPIRED = "EXPIRED"
+    INVALID_SIGNATURE = "INVALID_SIGNATURE"
+
+
+class TokenError(Exception):
+    """Raised by the parser and verifier on any parse/verification failure."""
+
+    def __init__(self, code: TokenErrorCode, message: str) -> None:
+        super().__init__(message)
+        self.code = code

--- a/sdks/python/packages/sudomimus-token/src/sudomimus_token/models.py
+++ b/sdks/python/packages/sudomimus-token/src/sudomimus_token/models.py
@@ -1,0 +1,41 @@
+"""Claim models for Sudomimus access and refresh tokens.
+
+Standard envelope claims (``iss``, ``aud``, ``iat``, ``exp``, ``jti``,
+``kty``, ``sub``) live in the JWT *header*; the body carries only the
+application-specific claims. This mirrors ``@sudomimus/token`` and the C#
+``Sudomimus.Token`` package.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class JwtHeader(BaseModel):
+    """Envelope claims carried in the JWT header segment."""
+
+    alg: str | None = None
+    typ: str | None = None
+    iss: str | None = None
+    aud: str | None = None
+    iat: int | None = None
+    exp: int | None = None
+    nbf: int | None = None
+    jti: str | None = None
+    sub: str | None = None
+    kty: str | None = None
+    ver: str | None = None
+
+
+class AccessTokenBody(BaseModel):
+    """Body claims carried in a Sudomimus access token."""
+
+    accountIdentifier: str
+    firstName: str
+    lastName: str | None = None
+
+
+class RefreshTokenBody(BaseModel):
+    """Body claims carried in a Sudomimus refresh token."""
+
+    accountIdentifier: str

--- a/sdks/python/packages/sudomimus-token/src/sudomimus_token/parser.py
+++ b/sdks/python/packages/sudomimus-token/src/sudomimus_token/parser.py
@@ -1,0 +1,87 @@
+"""Structural JWT parsers (no signature verification)."""
+
+from __future__ import annotations
+
+import binascii
+from typing import TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+from ._codec import decode_base64url
+from .errors import TokenError, TokenErrorCode
+from .models import AccessTokenBody, JwtHeader, RefreshTokenBody
+from .token import JwtToken
+
+_ModelT = TypeVar("_ModelT", bound=BaseModel)
+_BodyT = TypeVar("_BodyT", AccessTokenBody, RefreshTokenBody)
+
+
+def peek_header(jwt: str) -> JwtHeader:
+    """Decode and return only the header segment.
+
+    Useful for inspecting ``kty`` or ``aud`` before a full typed parse — the
+    verifier checks ``kty`` first so a wrong-type token gives a clearer error
+    than a body-shape mismatch would.
+    """
+    header_segment = _segments(jwt)[0]
+    try:
+        header_bytes = decode_base64url(header_segment)
+    except (binascii.Error, ValueError) as exc:
+        raise TokenError(
+            TokenErrorCode.INVALID_JWT, f"Failed to decode JWT header segment: {exc}"
+        ) from exc
+    return _validate(JwtHeader, header_bytes, "header")
+
+
+def parse_access_token(jwt: str) -> JwtToken[AccessTokenBody]:
+    """Parse a Sudomimus access token (header + :class:`AccessTokenBody`)."""
+    return _parse(jwt, AccessTokenBody)
+
+
+def parse_refresh_token(jwt: str) -> JwtToken[RefreshTokenBody]:
+    """Parse a Sudomimus refresh token (header + :class:`RefreshTokenBody`)."""
+    return _parse(jwt, RefreshTokenBody)
+
+
+def _segments(jwt: str) -> list[str]:
+    if not jwt:
+        raise TokenError(TokenErrorCode.INVALID_JWT, "Token is empty.")
+    parts = jwt.split(".")
+    if len(parts) != 3:
+        raise TokenError(
+            TokenErrorCode.INVALID_JWT,
+            f"Token must have exactly three dot-separated segments; got {len(parts)}.",
+        )
+    return parts
+
+
+def _validate(model: type[_ModelT], data: bytes, label: str) -> _ModelT:
+    try:
+        return model.model_validate_json(data)
+    except ValidationError as exc:
+        raise TokenError(
+            TokenErrorCode.INVALID_JWT, f"Failed to deserialize JWT {label}: {exc}"
+        ) from exc
+
+
+def _parse(jwt: str, body_model: type[_BodyT]) -> JwtToken[_BodyT]:
+    header_segment, body_segment, signature_segment = _segments(jwt)
+    try:
+        header_bytes = decode_base64url(header_segment)
+        body_bytes = decode_base64url(body_segment)
+        signature_bytes = decode_base64url(signature_segment)
+    except (binascii.Error, ValueError) as exc:
+        raise TokenError(
+            TokenErrorCode.INVALID_JWT, f"Failed to decode JWT segments: {exc}"
+        ) from exc
+
+    header = _validate(JwtHeader, header_bytes, "header")
+    body = _validate(body_model, body_bytes, "body")
+    signing_input = f"{header_segment}.{body_segment}".encode("ascii")
+    return JwtToken(
+        raw=jwt,
+        signing_input=signing_input,
+        signature=signature_bytes,
+        header=header,
+        body=body,
+    )

--- a/sdks/python/packages/sudomimus-token/src/sudomimus_token/token.py
+++ b/sdks/python/packages/sudomimus-token/src/sudomimus_token/token.py
@@ -1,0 +1,43 @@
+"""Parsed-token container with signature and expiration checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Generic, TypeVar
+
+from ._codec import verify_rs256
+from .models import AccessTokenBody, JwtHeader, RefreshTokenBody
+
+BodyT = TypeVar("BodyT", bound="AccessTokenBody | RefreshTokenBody")
+
+
+@dataclass(frozen=True, slots=True)
+class JwtToken(Generic[BodyT]):
+    """A parsed Sudomimus JWT.
+
+    Exposes the header (envelope claims), the typed body, and the verbatim
+    ``signing_input`` so callers can re-verify the signature against their
+    own public key without re-encoding the deserialized claims.
+    """
+
+    raw: str
+    signing_input: bytes
+    signature: bytes
+    header: JwtHeader
+    body: BodyT
+
+    def verify_signature(self, public_key_pem: str) -> bool:
+        """Return ``True`` when the signature matches the given RSA public key."""
+        return verify_rs256(public_key_pem, self.signing_input, self.signature)
+
+    def verify_expiration(self, now: datetime) -> bool:
+        """Return ``True`` when the token's ``exp`` claim is still in the future."""
+        if self.header.exp is None:
+            return False
+        expires_at = datetime.fromtimestamp(self.header.exp, tz=UTC)
+        return now < expires_at
+
+
+AccessToken = JwtToken[AccessTokenBody]
+RefreshToken = JwtToken[RefreshTokenBody]

--- a/sdks/python/packages/sudomimus-token/src/sudomimus_token/verifier.py
+++ b/sdks/python/packages/sudomimus-token/src/sudomimus_token/verifier.py
@@ -1,0 +1,126 @@
+"""End-to-end token verification (structure, key type, audience, expiry, signature)."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import TypeVar
+
+from .errors import TokenError, TokenErrorCode
+from .models import AccessTokenBody, RefreshTokenBody
+from .parser import parse_access_token, parse_refresh_token, peek_header
+from .token import JwtToken
+
+ACCESS_TOKEN_KEY_TYPE = "Access"
+REFRESH_TOKEN_KEY_TYPE = "Refresh"
+
+PublicKeyResolver = Callable[[str], str]
+AsyncPublicKeyResolver = Callable[[str], Awaitable[str]]
+
+_BodyT = TypeVar("_BodyT", AccessTokenBody, RefreshTokenBody)
+
+
+def _now_utc() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def _check_before_signature(
+    jwt: str,
+    expected_key_type: str,
+    parser: Callable[[str], JwtToken[_BodyT]],
+    now: datetime,
+) -> tuple[JwtToken[_BodyT], str]:
+    """Run every check that does not need the public key; return token + audience.
+
+    Peek the header first so a wrong-type token surfaces as ``WRONG_KEY_TYPE``
+    rather than ``INVALID_JWT`` (which is what a body-shape mismatch would
+    otherwise produce — a refresh body has no ``firstName``).
+    """
+    peeked = peek_header(jwt)
+    if peeked.kty != expected_key_type:
+        raise TokenError(
+            TokenErrorCode.WRONG_KEY_TYPE,
+            f'Expected key type "{expected_key_type}", got "{peeked.kty or ""}".',
+        )
+
+    parsed = parser(jwt)
+    audience = parsed.header.aud
+    if not audience:
+        raise TokenError(
+            TokenErrorCode.MISSING_AUDIENCE,
+            "Token is missing the `aud` (applicationAnchor) header.",
+        )
+
+    if not parsed.verify_expiration(now):
+        raise TokenError(TokenErrorCode.EXPIRED, "Token has expired.")
+
+    return parsed, audience
+
+
+def _check_signature(parsed: JwtToken[_BodyT], public_key_pem: str) -> JwtToken[_BodyT]:
+    if not parsed.verify_signature(public_key_pem):
+        raise TokenError(
+            TokenErrorCode.INVALID_SIGNATURE,
+            "Token signature does not match the application public key.",
+        )
+    return parsed
+
+
+class TokenVerifier:
+    """Synchronous verifier driven by a public-key resolver."""
+
+    def __init__(
+        self,
+        resolver: PublicKeyResolver,
+        *,
+        clock: Callable[[], datetime] = _now_utc,
+    ) -> None:
+        self._resolver = resolver
+        self._clock = clock
+
+    def verify_access_token(self, jwt: str) -> JwtToken[AccessTokenBody]:
+        return self._verify(jwt, ACCESS_TOKEN_KEY_TYPE, parse_access_token)
+
+    def verify_refresh_token(self, jwt: str) -> JwtToken[RefreshTokenBody]:
+        return self._verify(jwt, REFRESH_TOKEN_KEY_TYPE, parse_refresh_token)
+
+    def _verify(
+        self,
+        jwt: str,
+        expected_key_type: str,
+        parser: Callable[[str], JwtToken[_BodyT]],
+    ) -> JwtToken[_BodyT]:
+        parsed, audience = _check_before_signature(
+            jwt, expected_key_type, parser, self._clock()
+        )
+        return _check_signature(parsed, self._resolver(audience))
+
+
+class AsyncTokenVerifier:
+    """Asynchronous verifier with an awaitable public-key resolver."""
+
+    def __init__(
+        self,
+        resolver: AsyncPublicKeyResolver,
+        *,
+        clock: Callable[[], datetime] = _now_utc,
+    ) -> None:
+        self._resolver = resolver
+        self._clock = clock
+
+    async def verify_access_token(self, jwt: str) -> JwtToken[AccessTokenBody]:
+        return await self._verify(jwt, ACCESS_TOKEN_KEY_TYPE, parse_access_token)
+
+    async def verify_refresh_token(self, jwt: str) -> JwtToken[RefreshTokenBody]:
+        return await self._verify(jwt, REFRESH_TOKEN_KEY_TYPE, parse_refresh_token)
+
+    async def _verify(
+        self,
+        jwt: str,
+        expected_key_type: str,
+        parser: Callable[[str], JwtToken[_BodyT]],
+    ) -> JwtToken[_BodyT]:
+        parsed, audience = _check_before_signature(
+            jwt, expected_key_type, parser, self._clock()
+        )
+        return _check_signature(parsed, await self._resolver(audience))

--- a/sdks/python/packages/sudomimus-token/tests/test_token.py
+++ b/sdks/python/packages/sudomimus-token/tests/test_token.py
@@ -1,0 +1,145 @@
+"""Tests for parsing and verifying Sudomimus tokens."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from sudomimus_token import (
+    AsyncTokenVerifier,
+    TokenError,
+    TokenErrorCode,
+    TokenVerifier,
+    create_jwt,
+    decode_base64url,
+    encode_base64url,
+    parse_access_token,
+    peek_header,
+)
+
+ANCHOR = "app-anchor"
+
+
+def _keypair() -> tuple[str, str]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+    public_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("ascii")
+    return private_pem, public_pem
+
+
+def _mint(
+    private_pem: str,
+    *,
+    kty: str = "Access",
+    aud: str | None = ANCHOR,
+    exp_offset: int = 60,
+    body: dict | None = None,
+) -> str:
+    header: dict = {"kty": kty, "iat": int(time.time()), "exp": int(time.time()) + exp_offset}
+    if aud is not None:
+        header["aud"] = aud
+    default_body = (
+        {"accountIdentifier": "acct-1", "firstName": "Ada"}
+        if kty == "Access"
+        else {"accountIdentifier": "acct-1"}
+    )
+    return create_jwt(header, body if body is not None else default_body, private_pem)
+
+
+def test_base64url_round_trip() -> None:
+    data = b"\x00\x01\x02hello-world\xff\xfe"
+    assert decode_base64url(encode_base64url(data)) == data
+
+
+def test_verify_access_token_happy_path() -> None:
+    private_pem, public_pem = _keypair()
+    jwt = _mint(private_pem)
+    token = TokenVerifier(lambda _: public_pem).verify_access_token(jwt)
+    assert token.body.accountIdentifier == "acct-1"
+    assert token.body.firstName == "Ada"
+    assert token.header.aud == ANCHOR
+
+
+def test_verify_refresh_token_happy_path() -> None:
+    private_pem, public_pem = _keypair()
+    jwt = _mint(private_pem, kty="Refresh")
+    token = TokenVerifier(lambda _: public_pem).verify_refresh_token(jwt)
+    assert token.body.accountIdentifier == "acct-1"
+
+
+def test_wrong_key_type() -> None:
+    private_pem, public_pem = _keypair()
+    refresh_jwt = _mint(private_pem, kty="Refresh")
+    with pytest.raises(TokenError) as exc:
+        TokenVerifier(lambda _: public_pem).verify_access_token(refresh_jwt)
+    assert exc.value.code is TokenErrorCode.WRONG_KEY_TYPE
+
+
+def test_missing_audience() -> None:
+    private_pem, public_pem = _keypair()
+    jwt = _mint(private_pem, aud=None)
+    with pytest.raises(TokenError) as exc:
+        TokenVerifier(lambda _: public_pem).verify_access_token(jwt)
+    assert exc.value.code is TokenErrorCode.MISSING_AUDIENCE
+
+
+def test_expired_token() -> None:
+    private_pem, public_pem = _keypair()
+    jwt = _mint(private_pem, exp_offset=-10)
+    with pytest.raises(TokenError) as exc:
+        TokenVerifier(lambda _: public_pem).verify_access_token(jwt)
+    assert exc.value.code is TokenErrorCode.EXPIRED
+
+
+def test_invalid_signature_wrong_key() -> None:
+    private_pem, _ = _keypair()
+    _, other_public_pem = _keypair()
+    jwt = _mint(private_pem)
+    with pytest.raises(TokenError) as exc:
+        TokenVerifier(lambda _: other_public_pem).verify_access_token(jwt)
+    assert exc.value.code is TokenErrorCode.INVALID_SIGNATURE
+
+
+def test_malformed_jwt() -> None:
+    _, public_pem = _keypair()
+    with pytest.raises(TokenError) as exc:
+        TokenVerifier(lambda _: public_pem).verify_access_token("not-a-jwt")
+    assert exc.value.code is TokenErrorCode.INVALID_JWT
+
+
+def test_peek_header_reads_key_type() -> None:
+    private_pem, _ = _keypair()
+    jwt = _mint(private_pem)
+    assert peek_header(jwt).kty == "Access"
+
+
+def test_parse_does_not_verify_signature() -> None:
+    private_pem, _ = _keypair()
+    jwt = _mint(private_pem)
+    # Parsing succeeds without any public key; only the verifier checks trust.
+    parsed = parse_access_token(jwt)
+    assert parsed.body.firstName == "Ada"
+
+
+def test_async_verifier_happy_path() -> None:
+    private_pem, public_pem = _keypair()
+    jwt = _mint(private_pem)
+
+    async def resolver(_: str) -> str:
+        return public_pem
+
+    async def run() -> str:
+        token = await AsyncTokenVerifier(resolver).verify_access_token(jwt)
+        return token.body.accountIdentifier
+
+    assert asyncio.run(run()) == "acct-1"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -10,6 +10,7 @@ members = ["packages/*"]
 [tool.uv.sources]
 sudomimus-connect = { workspace = true }
 sudomimus-native = { workspace = true }
+sudomimus-token = { workspace = true }
 
 [dependency-groups]
 dev = [
@@ -19,7 +20,12 @@ dev = [
     "ruff>=0.8",
     "sudomimus-connect",
     "sudomimus-native",
+    "sudomimus-token",
 ]
+
+[tool.mypy]
+python_version = "3.11"
+exclude = ['/_generated/']
 
 [tool.ruff]
 line-length = 100

--- a/sdks/python/tasks.py
+++ b/sdks/python/tasks.py
@@ -47,6 +47,7 @@ def generate() -> None:
                 "3.11",
                 "--use-schema-description",
                 "--use-double-quotes",
+                "--field-constraints",
                 "--disable-timestamp",
             ],
             check=True,

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -12,6 +12,7 @@ members = [
     "sudomimus-connect",
     "sudomimus-native",
     "sudomimus-sdks-python",
+    "sudomimus-token",
 ]
 
 [[package]]
@@ -130,6 +131,76 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -148,6 +219,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
 ]
 
 [[package]]
@@ -520,6 +650,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -782,12 +921,14 @@ source = { editable = "packages/sudomimus-connect" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "sudomimus-token" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "pydantic", specifier = ">=2.7" },
+    { name = "sudomimus-token", editable = "packages/sudomimus-token" },
 ]
 
 [[package]]
@@ -818,6 +959,7 @@ dev = [
     { name = "ruff" },
     { name = "sudomimus-connect" },
     { name = "sudomimus-native" },
+    { name = "sudomimus-token" },
 ]
 
 [package.metadata]
@@ -830,6 +972,22 @@ dev = [
     { name = "ruff", specifier = ">=0.8" },
     { name = "sudomimus-connect", editable = "packages/sudomimus-connect" },
     { name = "sudomimus-native", editable = "packages/sudomimus-native" },
+    { name = "sudomimus-token", editable = "packages/sudomimus-token" },
+]
+
+[[package]]
+name = "sudomimus-token"
+version = "0.0.1"
+source = { editable = "packages/sudomimus-token" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "cryptography", specifier = ">=42" },
+    { name = "pydantic", specifier = ">=2.7" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add sudomimus-token (parse/verify access & refresh JWTs via a hand-rolled
cryptography RS256 codec) and flesh out sudomimus-connect and
sudomimus-native with sync and async clients. Regenerate the stale spec
models, wire client-auth JWT signing for /establish, add public-key
caching and token verification to Connect, and bring Python lint/type/test
into CI (mypy) and the Makefile.

https://claude.ai/code/session_01Ld2PtrvkBVUZ7oAoM4GXJ1