### PR TITLE
Update spec submodule to add Connect session endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This repository hosts client SDKs for the public Sudomimus APIs, organized by la
 
 | Language | Package | Purpose | Status |
 | --- | --- | --- | --- |
-| TypeScript | [`@sudomimus/connect`](sdks/typescript/packages/connect) | Token exchange (Establish / StatusPoll / Redeem / Refresh / Info) | alpha |
+| TypeScript | [`@sudomimus/connect`](sdks/typescript/packages/connect) | Token exchange (Establish / StatusPoll / Redeem / Refresh / Info / Introspect / Logout / RevokeAll) | alpha |
 | TypeScript | [`@sudomimus/token`](sdks/typescript/packages/token) | Parse and verify Sudomimus access / refresh JWTs | alpha |
 | TypeScript | [`@sudomimus/native`](sdks/typescript/packages/native) | Direct-issue (Steam ticket / access key) | alpha |
-| Python | [`sudomimus-connect`](sdks/python/packages/sudomimus-connect) | Token exchange (Establish / StatusPoll / Redeem / Refresh / Info) | alpha |
+| Python | [`sudomimus-connect`](sdks/python/packages/sudomimus-connect) | Token exchange (Establish / StatusPoll / Redeem / Refresh / Info / Introspect / Logout / RevokeAll) | alpha |
 | Python | [`sudomimus-token`](sdks/python/packages/sudomimus-token) | Parse and verify Sudomimus access / refresh JWTs | alpha |
 | Python | [`sudomimus-native`](sdks/python/packages/sudomimus-native) | Direct-issue (Steam ticket / access key) | alpha |
 

--- a/examples/typescript/node/src/index.ts
+++ b/examples/typescript/node/src/index.ts
@@ -9,6 +9,7 @@
  *   5. Poll /status-poll until REALIZED.
  *   6. POST /redeem and verify the issued access token.
  *   7. Print the accountIdentifier as the "login succeeded" signal.
+ *   8. POST /logout to revoke the session's refresh token.
  */
 
 import { ConnectClient, RETURN_METHOD } from "@sudomimus/connect";
@@ -73,7 +74,13 @@ while (confirmationKey === undefined) {
 }
 
 console.log("\nInquiry realized. Calling /redeem ...");
-const { accessToken } = await client.redeem({ exposureKey, hiddenKey, confirmationKey });
+const { accessToken, refreshToken } = await client.redeem({ exposureKey, hiddenKey, confirmationKey });
 const verified = await client.verifyAccessToken(accessToken);
 
 console.log(`\n✓ Login successful. accountIdentifier=${verified.body.accountIdentifier}`);
+
+// Tear the session back down. /logout revokes the refresh token; possession
+// of the token authorizes the revocation, so no client-auth JWT is needed.
+console.log("\nCalling /logout ...");
+const { revoked } = await client.logout({ refreshToken });
+console.log(`✓ Session revoked=${revoked}`);

--- a/sdks/python/packages/sudomimus-connect/README.md
+++ b/sdks/python/packages/sudomimus-connect/README.md
@@ -2,8 +2,10 @@
 
 Python SDK for the Sudomimus Connect API — the token-exchange entry point:
 establish an authentication inquiry, poll its status, redeem it for
-application tokens, refresh access tokens, and fetch localized application
-metadata. Includes client-auth JWT signing for `/establish` and token
+application tokens, refresh access tokens, fetch localized application
+metadata, introspect a session's revocation status, and revoke sessions (one
+via `/logout` or every session of an account via `/revoke-all`). Includes
+client-auth JWT signing for `/establish` and `/revoke-all`, and token
 verification (via [`sudomimus-token`](../sudomimus-token)).
 
 ## Install
@@ -50,6 +52,22 @@ access = client.verify_access_token(tokens.accessToken)
 print(access.body.accountIdentifier)
 ```
 
+Introspect and revoke sessions. `introspect` and `logout` need no client auth;
+`revoke_all` is an application-authority action and requires `client_auth`
+(exactly like `establish`):
+
+```python
+# Near-real-time revocation check; status is "active"/"revoked"/"expired"/"not_found".
+state = client.introspect(IntrospectRequest(accessToken=tokens.accessToken))
+
+# Revoke one session (idempotent); possession of the refresh token authorizes it.
+client.logout(LogoutRequest(refreshToken=tokens.refreshToken))
+
+# Revoke every session of an account for the calling application.
+revoked = client.revoke_all(RevokeAllRequest(accountIdentifier="acct-1"))
+print(revoked.revokedCount)
+```
+
 An `AsyncConnectClient` with the same methods is available for `asyncio`
 callers (its BYO signer may be sync or async). Non-2xx responses raise
 `ConnectApiError` (inspect `.status` and `.reason`).
@@ -66,10 +84,16 @@ from sudomimus_connect import (
     EstablishResponse,
     InfoRequest,
     InfoResponse,
+    IntrospectRequest,
+    IntrospectResponse,
+    LogoutRequest,
+    LogoutResponse,
     RedeemRequest,
     RedeemResponse,
     RefreshRequest,
     RefreshResponse,
+    RevokeAllRequest,
+    RevokeAllResponse,
     StatusPollRequest,
     StatusPollResponse,
 )

--- a/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/__init__.py
+++ b/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/__init__.py
@@ -2,8 +2,11 @@
 
 Token-exchange client for the Sudomimus authentication platform: establish an
 inquiry, poll its status, redeem it for application tokens, refresh access
-tokens, and fetch localized application metadata. Includes client-auth JWT
-signing for ``/establish`` and token verification (via ``sudomimus-token``).
+tokens, fetch localized application metadata, introspect a session's
+revocation status, and revoke sessions (a single session via ``/logout`` or
+every session of an account via ``/revoke-all``). Includes client-auth JWT
+signing for ``/establish`` and ``/revoke-all``, and token verification (via
+``sudomimus-token``).
 """
 
 from __future__ import annotations
@@ -17,6 +20,10 @@ from ._generated.models import (
     HealthResponse,
     InfoRequest,
     InfoResponse,
+    IntrospectRequest,
+    IntrospectResponse,
+    LogoutRequest,
+    LogoutResponse,
     RealizeRuleConstraint,
     RealizeRuleEmailPayload,
     RedeemRequest,
@@ -27,6 +34,8 @@ from ._generated.models import (
     ReturnMethodDeclaration,
     ReturnMethodReveal,
     ReturnMethodStatusPoll,
+    RevokeAllRequest,
+    RevokeAllResponse,
     StatusPollPendingResponse,
     StatusPollRealizedResponse,
     StatusPollRequest,
@@ -78,6 +87,10 @@ __all__ = [
     "HealthResponse",
     "InfoRequest",
     "InfoResponse",
+    "IntrospectRequest",
+    "IntrospectResponse",
+    "LogoutRequest",
+    "LogoutResponse",
     "RealizeRuleConstraint",
     "RealizeRuleEmailPayload",
     "RedeemRequest",
@@ -88,6 +101,8 @@ __all__ = [
     "ReturnMethodDeclaration",
     "ReturnMethodReveal",
     "ReturnMethodStatusPoll",
+    "RevokeAllRequest",
+    "RevokeAllResponse",
     "StatusPollPendingResponse",
     "StatusPollRealizedResponse",
     "StatusPollRequest",

--- a/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/_generated/models.py
+++ b/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/_generated/models.py
@@ -92,6 +92,63 @@ class InfoResponse(BaseModel):
     )
 
 
+class IntrospectRequest(BaseModel):
+    accessToken: str = Field(
+        ...,
+        description="A Sudomimus-issued access token (JWT). Its signature is verified; its own expiry is not enforced.",
+    )
+
+
+class Status2(StrEnum):
+    """
+    Revocation state of the session behind the access token. `not_found`
+    covers an unknown session or one belonging to a different application.
+
+    """
+
+    active = "active"
+    revoked = "revoked"
+    expired = "expired"
+    not_found = "not_found"
+
+
+class IntrospectResponse(BaseModel):
+    status: Status2 = Field(
+        ...,
+        description="Revocation state of the session behind the access token. `not_found`\ncovers an unknown session or one belonging to a different application.\n",
+    )
+    recommendedRecheckSeconds: int = Field(
+        ...,
+        description="Suggested minimum number of seconds to cache this result before re-checking.",
+    )
+
+
+class LogoutRequest(BaseModel):
+    refreshToken: str = Field(
+        ..., description="The refresh token (JWT) whose session should be revoked."
+    )
+
+
+class LogoutResponse(BaseModel):
+    revoked: bool = Field(
+        ...,
+        description="True if the session is now revoked, including sessions that were already revoked or expired.",
+    )
+
+
+class RevokeAllRequest(BaseModel):
+    accountIdentifier: str = Field(
+        ...,
+        description="Identifier of the account whose sessions should be revoked for the calling application.",
+    )
+
+
+class RevokeAllResponse(BaseModel):
+    revokedCount: int = Field(
+        ..., description="Number of refresh tokens that were revoked."
+    )
+
+
 class Method(StrEnum):
     """
     Which authentication method this constraint narrows to.

--- a/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/async_client.py
+++ b/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/async_client.py
@@ -16,10 +16,16 @@ from ._generated.models import (
     HealthResponse,
     InfoRequest,
     InfoResponse,
+    IntrospectRequest,
+    IntrospectResponse,
+    LogoutRequest,
+    LogoutResponse,
     RedeemRequest,
     RedeemResponse,
     RefreshRequest,
     RefreshResponse,
+    RevokeAllRequest,
+    RevokeAllResponse,
     StatusPollRequest,
     StatusPollResponse,
 )
@@ -85,28 +91,9 @@ class AsyncConnectClient:
         return _handle(response, HealthResponse)
 
     async def establish(self, request: EstablishRequest) -> EstablishResponse:
-        if self._client_auth is None:
-            raise ConnectConfigError(
-                "AsyncConnectClient.establish() requires client_auth. "
-                "Pass client_auth to the AsyncConnectClient constructor."
-            )
-
-        # Serialize once: these exact bytes are what the server hashes against
-        # the JWT's body_sha256 claim, so they must match the wire body.
-        raw_body = request.model_dump_json(exclude_none=True)
-
-        if isinstance(self._client_auth, ConnectClientAuthWithSigner):
-            signed = self._client_auth.signer(raw_body)
-            jwt = await signed if inspect.isawaitable(signed) else signed
-        else:
-            jwt = sign_establish_client_jwt(self._client_auth, raw_body)
-
-        response = await self._client.post(
-            f"{self._base_url}/establish",
-            content=raw_body,
-            headers={**_JSON_HEADERS, "Authorization": f"{CLIENT_JWT_AUTH_SCHEME} {jwt}"},
+        return await self._post_with_client_auth(
+            "/establish", request, EstablishResponse, method_name="establish"
         )
-        return _handle(response, EstablishResponse)
 
     async def status_poll(self, request: StatusPollRequest) -> StatusPollResponse:
         return await self._post("/status-poll", request, StatusPollResponse)
@@ -119,6 +106,17 @@ class AsyncConnectClient:
 
     async def info(self, request: InfoRequest) -> InfoResponse:
         return await self._post("/info", request, InfoResponse)
+
+    async def introspect(self, request: IntrospectRequest) -> IntrospectResponse:
+        return await self._post("/introspect", request, IntrospectResponse)
+
+    async def logout(self, request: LogoutRequest) -> LogoutResponse:
+        return await self._post("/logout", request, LogoutResponse)
+
+    async def revoke_all(self, request: RevokeAllRequest) -> RevokeAllResponse:
+        return await self._post_with_client_auth(
+            "/revoke-all", request, RevokeAllResponse, method_name="revoke_all"
+        )
 
     async def get_application_public_key(
         self,
@@ -156,5 +154,36 @@ class AsyncConnectClient:
         raw = request.model_dump_json(exclude_none=True)
         response = await self._client.post(
             f"{self._base_url}{path}", content=raw, headers=_JSON_HEADERS
+        )
+        return _handle(response, response_model)
+
+    async def _post_with_client_auth(
+        self,
+        path: str,
+        request: BaseModel,
+        response_model: type[_ResponseT],
+        *,
+        method_name: str,
+    ) -> _ResponseT:
+        if self._client_auth is None:
+            raise ConnectConfigError(
+                f"AsyncConnectClient.{method_name}() requires client_auth. "
+                "Pass client_auth to the AsyncConnectClient constructor."
+            )
+
+        # Serialize once: these exact bytes are what the server hashes against
+        # the JWT's body_sha256 claim, so they must match the wire body.
+        raw_body = request.model_dump_json(exclude_none=True)
+
+        if isinstance(self._client_auth, ConnectClientAuthWithSigner):
+            signed = self._client_auth.signer(raw_body)
+            jwt = await signed if inspect.isawaitable(signed) else signed
+        else:
+            jwt = sign_establish_client_jwt(self._client_auth, raw_body)
+
+        response = await self._client.post(
+            f"{self._base_url}{path}",
+            content=raw_body,
+            headers={**_JSON_HEADERS, "Authorization": f"{CLIENT_JWT_AUTH_SCHEME} {jwt}"},
         )
         return _handle(response, response_model)

--- a/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/client.py
+++ b/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/client.py
@@ -16,10 +16,16 @@ from ._generated.models import (
     HealthResponse,
     InfoRequest,
     InfoResponse,
+    IntrospectRequest,
+    IntrospectResponse,
+    LogoutRequest,
+    LogoutResponse,
     RedeemRequest,
     RedeemResponse,
     RefreshRequest,
     RefreshResponse,
+    RevokeAllRequest,
+    RevokeAllResponse,
     StatusPollRequest,
     StatusPollResponse,
 )
@@ -86,32 +92,9 @@ class ConnectClient:
         return _handle(response, HealthResponse)
 
     def establish(self, request: EstablishRequest) -> EstablishResponse:
-        if self._client_auth is None:
-            raise ConnectConfigError(
-                "ConnectClient.establish() requires client_auth. "
-                "Pass client_auth to the ConnectClient constructor."
-            )
-
-        # Serialize once: the exact bytes here are what the server hashes
-        # against the JWT's body_sha256 claim, so they must match the wire body.
-        raw_body = request.model_dump_json(exclude_none=True)
-
-        if isinstance(self._client_auth, ConnectClientAuthWithSigner):
-            jwt = self._client_auth.signer(raw_body)
-            if not isinstance(jwt, str):
-                raise ConnectConfigError(
-                    "client_auth.signer returned an awaitable; use AsyncConnectClient "
-                    "for async signers."
-                )
-        else:
-            jwt = sign_establish_client_jwt(self._client_auth, raw_body)
-
-        response = self._client.post(
-            f"{self._base_url}/establish",
-            content=raw_body,
-            headers={**_JSON_HEADERS, "Authorization": f"{CLIENT_JWT_AUTH_SCHEME} {jwt}"},
+        return self._post_with_client_auth(
+            "/establish", request, EstablishResponse, method_name="establish"
         )
-        return _handle(response, EstablishResponse)
 
     def status_poll(self, request: StatusPollRequest) -> StatusPollResponse:
         return self._post("/status-poll", request, StatusPollResponse)
@@ -124,6 +107,17 @@ class ConnectClient:
 
     def info(self, request: InfoRequest) -> InfoResponse:
         return self._post("/info", request, InfoResponse)
+
+    def introspect(self, request: IntrospectRequest) -> IntrospectResponse:
+        return self._post("/introspect", request, IntrospectResponse)
+
+    def logout(self, request: LogoutRequest) -> LogoutResponse:
+        return self._post("/logout", request, LogoutResponse)
+
+    def revoke_all(self, request: RevokeAllRequest) -> RevokeAllResponse:
+        return self._post_with_client_auth(
+            "/revoke-all", request, RevokeAllResponse, method_name="revoke_all"
+        )
 
     def get_application_public_key(
         self,
@@ -161,6 +155,41 @@ class ConnectClient:
         raw = request.model_dump_json(exclude_none=True)
         response = self._client.post(
             f"{self._base_url}{path}", content=raw, headers=_JSON_HEADERS
+        )
+        return _handle(response, response_model)
+
+    def _post_with_client_auth(
+        self,
+        path: str,
+        request: BaseModel,
+        response_model: type[_ResponseT],
+        *,
+        method_name: str,
+    ) -> _ResponseT:
+        if self._client_auth is None:
+            raise ConnectConfigError(
+                f"ConnectClient.{method_name}() requires client_auth. "
+                "Pass client_auth to the ConnectClient constructor."
+            )
+
+        # Serialize once: the exact bytes here are what the server hashes
+        # against the JWT's body_sha256 claim, so they must match the wire body.
+        raw_body = request.model_dump_json(exclude_none=True)
+
+        if isinstance(self._client_auth, ConnectClientAuthWithSigner):
+            jwt = self._client_auth.signer(raw_body)
+            if not isinstance(jwt, str):
+                raise ConnectConfigError(
+                    "client_auth.signer returned an awaitable; use AsyncConnectClient "
+                    "for async signers."
+                )
+        else:
+            jwt = sign_establish_client_jwt(self._client_auth, raw_body)
+
+        response = self._client.post(
+            f"{self._base_url}{path}",
+            content=raw_body,
+            headers={**_JSON_HEADERS, "Authorization": f"{CLIENT_JWT_AUTH_SCHEME} {jwt}"},
         )
         return _handle(response, response_model)
 

--- a/sdks/python/packages/sudomimus-connect/tests/test_smoke.py
+++ b/sdks/python/packages/sudomimus-connect/tests/test_smoke.py
@@ -20,8 +20,11 @@ from sudomimus_connect import (
     ConnectClientAuthWithSigner,
     ConnectConfigError,
     EstablishRequest,
+    IntrospectRequest,
+    LogoutRequest,
     RedeemRequest,
     RefreshRequest,
+    RevokeAllRequest,
     StatusPollRequest,
     sha256_base64,
 )
@@ -135,6 +138,61 @@ def test_redeem_happy_path() -> None:
             RedeemRequest(exposureKey="ek", hiddenKey="hk", confirmationKey="ck")
         )
     assert result.accessToken == "a.t"
+
+
+def test_introspect_sends_no_client_auth() -> None:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["auth"] = request.headers.get("Authorization")
+        captured["path"] = request.url.path
+        return httpx.Response(200, json={"status": "active", "recommendedRecheckSeconds": 30})
+
+    with _client(handler) as client:
+        result = client.introspect(IntrospectRequest(accessToken="a.t"))
+
+    assert result.status == "active"
+    assert result.recommendedRecheckSeconds == 30
+    assert captured["path"] == "/introspect"
+    assert captured["auth"] is None
+
+
+def test_logout_revokes_session() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/logout"
+        return httpx.Response(200, json={"revoked": True})
+
+    with _client(handler) as client:
+        result = client.logout(LogoutRequest(refreshToken="r.t"))
+    assert result.revoked is True
+
+
+def test_revoke_all_requires_client_auth() -> None:
+    with _client(lambda r: httpx.Response(200)) as client, pytest.raises(ConnectConfigError):
+        client.revoke_all(RevokeAllRequest(accountIdentifier="acct-1"))
+
+
+def test_revoke_all_signs_request_with_matching_body_hash() -> None:
+    private_pem, _ = _keypair()
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["auth"] = request.headers["Authorization"]
+        captured["raw"] = request.content.decode("utf-8")
+        captured["path"] = request.url.path
+        return httpx.Response(200, json={"revokedCount": 2})
+
+    auth = ConnectClientAuthWithKey(application_anchor="my-app", private_key_pem=private_pem)
+    with _client(handler, client_auth=auth) as client:
+        result = client.revoke_all(RevokeAllRequest(accountIdentifier="acct-1"))
+
+    assert result.revokedCount == 2
+    assert captured["path"] == "/revoke-all"
+    scheme, _, jwt = captured["auth"].partition(" ")
+    assert scheme == "SudomimusClientJWT"
+    claims = json.loads(decode_base64url(jwt.split(".")[1]))
+    assert claims["iss"] == "my-app"
+    assert claims["body_sha256"] == sha256_base64(captured["raw"])
 
 
 def test_error_with_reason() -> None:
@@ -258,3 +316,30 @@ def test_async_establish_with_async_signer() -> None:
             return result.exposureKey
 
     assert asyncio.run(run()) == "ek"
+
+
+def test_async_logout_and_revoke_all() -> None:
+    private_pem, _ = _keypair()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/logout":
+            assert request.headers.get("Authorization") is None
+            return httpx.Response(200, json={"revoked": True})
+        assert request.url.path == "/revoke-all"
+        assert request.headers["Authorization"].startswith("SudomimusClientJWT ")
+        return httpx.Response(200, json={"revokedCount": 5})
+
+    auth = ConnectClientAuthWithKey(application_anchor="my-app", private_key_pem=private_pem)
+
+    async def run() -> tuple[bool, int]:
+        async with AsyncConnectClient(
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+            client_auth=auth,
+        ) as client:
+            logged_out = await client.logout(LogoutRequest(refreshToken="r.t"))
+            revoked = await client.revoke_all(RevokeAllRequest(accountIdentifier="acct-1"))
+            return logged_out.revoked, revoked.revokedCount
+
+    revoked, count = asyncio.run(run())
+    assert revoked is True
+    assert count == 5

--- a/sdks/typescript/packages/connect/README.md
+++ b/sdks/typescript/packages/connect/README.md
@@ -1,6 +1,6 @@
 # @sudomimus/connect
 
-TypeScript SDK for the [Sudomimus](https://sudomimus.com) Connect API — the public entry point for integrating applications. Establish an inquiry, poll for status, redeem for tokens, refresh access tokens, and fetch localized application metadata.
+TypeScript SDK for the [Sudomimus](https://sudomimus.com) Connect API — the public entry point for integrating applications. Establish an inquiry, poll for status, redeem for tokens, refresh access tokens, fetch localized application metadata, introspect a session's revocation status, and revoke sessions (one via `/logout` or all of an account's via `/revoke-all`).
 
 ## Install
 
@@ -71,6 +71,28 @@ The public key cache is per-`ConnectClient` instance and keyed by `applicationAn
 
 If you only need to verify tokens (you are an application backend and do not drive the auth flow), depend on [`@sudomimus/token`](../token) directly and provide your own `PublicKeyResolver`.
 
+### Sessions: introspect, logout, revoke
+
+```typescript
+// Near-real-time revocation check for a session behind an access token.
+// The token is self-authenticating (signature verified server-side); its own
+// expiry is NOT enforced here. Cache the answer for recommendedRecheckSeconds.
+const { status, recommendedRecheckSeconds } = await client.introspect({ accessToken });
+if (status !== "active") {
+    // status is one of "active" | "revoked" | "expired" | "not_found"
+}
+
+// Revoke a single session. Possession of the refresh token authorizes it, so
+// no client-auth JWT is required. Idempotent: already-revoked tokens report
+// revoked: true; unresolvable tokens report revoked: false.
+await client.logout({ refreshToken });
+
+// Revoke every session of an account for the calling application
+// ("log out everywhere"). This is an application-authority action, so — like
+// establish — it requires a clientAuth config on the ConnectClient.
+const { revokedCount } = await client.revokeAll({ accountIdentifier: "acct-1" });
+```
+
 ### Error handling
 
 All non-2xx HTTP responses surface as `ConnectApiError`:
@@ -106,6 +128,12 @@ import type {
     RefreshResponse,
     InfoRequest,
     InfoResponse,
+    IntrospectRequest,
+    IntrospectResponse,
+    LogoutRequest,
+    LogoutResponse,
+    RevokeAllRequest,
+    RevokeAllResponse,
     AuthAction,
     AuthActionCallback,
     AuthActionStatusPoll,

--- a/sdks/typescript/packages/connect/src/_generated/schema.ts
+++ b/sdks/typescript/packages/connect/src/_generated/schema.ts
@@ -122,6 +122,89 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/introspect": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Check whether the session behind an access token is still valid.
+         * @description Returns the revocation status of the refresh token (session) that the
+         *     supplied access token descends from. Intended for strict applications
+         *     that want near-real-time revocation: validate the access token offline
+         *     as usual, then call this endpoint — caching the result for at least
+         *     `recommendedRecheckSeconds` — to decide whether to keep trusting it.
+         *
+         *     The access token is self-authenticating: its signature is verified
+         *     against the issuing application's public key, so no client-auth JWT is
+         *     required. The access token's own expiry is NOT enforced here; the answer
+         *     describes the underlying session, not the access token's freshness.
+         *
+         */
+        post: operations["introspect"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Revoke the session behind a refresh token.
+         * @description Revokes the single session identified by the supplied refresh token
+         *     (RFC 7009 style). Possession of a genuine refresh token authorizes the
+         *     revocation, so no client-auth JWT is required.
+         *
+         *     The operation is idempotent: a token that is already revoked or expired
+         *     reports `revoked: true`, and a token that cannot be resolved reports
+         *     `revoked: false` without revealing whether it ever existed.
+         *
+         */
+        post: operations["logout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/revoke-all": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Revoke every session of an account for the calling application.
+         * @description Revokes all refresh tokens belonging to the given account that were
+         *     issued for the calling application (log out everywhere). This is an
+         *     application-authority action — not something a single session capability
+         *     can authorize — so it requires a client-auth JWT, exactly like
+         *     /establish. Revocation is scoped to the calling application; sessions of
+         *     the same account under other applications are unaffected.
+         *
+         */
+        post: operations["revokeAll"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -210,6 +293,37 @@ export interface components {
             applicationName: string;
             /** @description PEM-encoded application public key used to verify issued JWTs. */
             applicationPublicKey: string;
+        };
+        IntrospectRequest: {
+            /** @description A Sudomimus-issued access token (JWT). Its signature is verified; its own expiry is not enforced. */
+            accessToken: string;
+        };
+        IntrospectResponse: {
+            /**
+             * @description Revocation state of the session behind the access token. `not_found`
+             *     covers an unknown session or one belonging to a different application.
+             *
+             * @enum {string}
+             */
+            status: "active" | "revoked" | "expired" | "not_found";
+            /** @description Suggested minimum number of seconds to cache this result before re-checking. */
+            recommendedRecheckSeconds: number;
+        };
+        LogoutRequest: {
+            /** @description The refresh token (JWT) whose session should be revoked. */
+            refreshToken: string;
+        };
+        LogoutResponse: {
+            /** @description True if the session is now revoked, including sessions that were already revoked or expired. */
+            revoked: boolean;
+        };
+        RevokeAllRequest: {
+            /** @description Identifier of the account whose sessions should be revoked for the calling application. */
+            accountIdentifier: string;
+        };
+        RevokeAllResponse: {
+            /** @description Number of refresh tokens that were revoked. */
+            revokedCount: number;
         };
         AuthenticationRuleConstraint: {
             /**
@@ -477,6 +591,123 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["InfoResponse"];
+                };
+            };
+            /** @description Error response. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    introspect: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["IntrospectRequest"];
+            };
+        };
+        responses: {
+            /** @description Status of the session behind the access token. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IntrospectResponse"];
+                };
+            };
+            /** @description Access token missing, malformed, or with an invalid signature. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Error response. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    logout: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LogoutRequest"];
+            };
+        };
+        responses: {
+            /** @description Revocation outcome. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LogoutResponse"];
+                };
+            };
+            /** @description Error response. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    revokeAll: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RevokeAllRequest"];
+            };
+        };
+        responses: {
+            /** @description Number of sessions revoked. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RevokeAllResponse"];
+                };
+            };
+            /** @description Client-auth JWT missing, malformed, expired, or invalid. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
             /** @description Error response. */

--- a/sdks/typescript/packages/connect/src/client-auth.ts
+++ b/sdks/typescript/packages/connect/src/client-auth.ts
@@ -2,7 +2,7 @@
  * @author Sudomimus Contributors
  * @package Connect
  * @namespace ClientAuth
- * @description Client-auth JWT helpers for /establish
+ * @description Client-auth JWT helpers for /establish and /revoke-all
  */
 
 import { JWTCreator } from "@sudoo/jwt";

--- a/sdks/typescript/packages/connect/src/client.ts
+++ b/sdks/typescript/packages/connect/src/client.ts
@@ -18,10 +18,16 @@ import type {
     HealthResponse,
     InfoRequest,
     InfoResponse,
+    IntrospectRequest,
+    IntrospectResponse,
+    LogoutRequest,
+    LogoutResponse,
     RedeemRequest,
     RedeemResponse,
     RefreshRequest,
     RefreshResponse,
+    RevokeAllRequest,
+    RevokeAllResponse,
     StatusPollRequest,
     StatusPollResponse,
 } from "./declare";
@@ -65,32 +71,7 @@ export class ConnectClient {
 
     public async establish(request: EstablishRequest): Promise<EstablishResponse> {
 
-        if (this._clientAuth === undefined) {
-
-            throw new ConnectConfigError(
-                "ConnectClient.establish() requires a clientAuth config. Pass clientAuth in the ConnectClientOptions.",
-            );
-        }
-
-        // Serialize once. The exact bytes here are what the server hashes
-        // against the JWT's body_sha256 claim — letting fetch re-serialize
-        // (or going through _post) risks drift on key ordering or whitespace.
-        const rawBody: string = JSON.stringify(request);
-
-        const jwt: string = "signer" in this._clientAuth
-            ? await this._clientAuth.signer(rawBody)
-            : signEstablishClientJwt(this._clientAuth, rawBody);
-
-        const response: Response = await this._fetch(`${this._baseUrl}/establish`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "Accept": "application/json",
-                "Authorization": `${CLIENT_JWT_AUTH_SCHEME} ${jwt}`,
-            },
-            body: rawBody,
-        });
-        return this._handle<EstablishResponse>(response);
+        return this._postWithClientAuth<EstablishResponse>("establish", "/establish", request);
     }
 
     public async statusPoll(request: StatusPollRequest): Promise<StatusPollResponse> {
@@ -111,6 +92,21 @@ export class ConnectClient {
     public async info(request: InfoRequest): Promise<InfoResponse> {
 
         return this._post<InfoRequest, InfoResponse>("/info", request);
+    }
+
+    public async introspect(request: IntrospectRequest): Promise<IntrospectResponse> {
+
+        return this._post<IntrospectRequest, IntrospectResponse>("/introspect", request);
+    }
+
+    public async logout(request: LogoutRequest): Promise<LogoutResponse> {
+
+        return this._post<LogoutRequest, LogoutResponse>("/logout", request);
+    }
+
+    public async revokeAll(request: RevokeAllRequest): Promise<RevokeAllResponse> {
+
+        return this._postWithClientAuth<RevokeAllResponse>("revokeAll", "/revoke-all", request);
     }
 
     public async getApplicationPublicKey(
@@ -180,6 +176,40 @@ export class ConnectClient {
                 "Accept": "application/json",
             },
             body: JSON.stringify(body),
+        });
+        return this._handle<TRes>(response);
+    }
+
+    private async _postWithClientAuth<TRes>(
+        methodName: string,
+        path: string,
+        request: unknown,
+    ): Promise<TRes> {
+
+        if (this._clientAuth === undefined) {
+
+            throw new ConnectConfigError(
+                `ConnectClient.${methodName}() requires a clientAuth config. Pass clientAuth in the ConnectClientOptions.`,
+            );
+        }
+
+        // Serialize once. The exact bytes here are what the server hashes
+        // against the JWT's body_sha256 claim — letting fetch re-serialize
+        // (or going through _post) risks drift on key ordering or whitespace.
+        const rawBody: string = JSON.stringify(request);
+
+        const jwt: string = "signer" in this._clientAuth
+            ? await this._clientAuth.signer(rawBody)
+            : signEstablishClientJwt(this._clientAuth, rawBody);
+
+        const response: Response = await this._fetch(`${this._baseUrl}${path}`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "Authorization": `${CLIENT_JWT_AUTH_SCHEME} ${jwt}`,
+            },
+            body: rawBody,
         });
         return this._handle<TRes>(response);
     }

--- a/sdks/typescript/packages/connect/src/declare.ts
+++ b/sdks/typescript/packages/connect/src/declare.ts
@@ -23,6 +23,12 @@ export type RefreshRequest = components["schemas"]["RefreshRequest"];
 export type RefreshResponse = components["schemas"]["RefreshResponse"];
 export type InfoRequest = components["schemas"]["InfoRequest"];
 export type InfoResponse = components["schemas"]["InfoResponse"];
+export type IntrospectRequest = components["schemas"]["IntrospectRequest"];
+export type IntrospectResponse = components["schemas"]["IntrospectResponse"];
+export type LogoutRequest = components["schemas"]["LogoutRequest"];
+export type LogoutResponse = components["schemas"]["LogoutResponse"];
+export type RevokeAllRequest = components["schemas"]["RevokeAllRequest"];
+export type RevokeAllResponse = components["schemas"]["RevokeAllResponse"];
 
 export type AuthenticationRuleConstraint = components["schemas"]["AuthenticationRuleConstraint"];
 export type AuthenticationRulePasskeyPayload = components["schemas"]["AuthenticationRulePasskeyPayload"];
@@ -61,6 +67,14 @@ export const RETURN_METHOD = {
     REVEAL: "REVEAL",
 } as const;
 export type ReturnMethod = ReturnMethodDeclaration["type"];
+
+export const INTROSPECT_STATUS = {
+    ACTIVE: "active",
+    REVOKED: "revoked",
+    EXPIRED: "expired",
+    NOT_FOUND: "not_found",
+} as const;
+export type IntrospectStatus = IntrospectResponse["status"];
 
 /**
  * Signature for a BYO (bring-your-own) client-auth JWT signer.

--- a/sdks/typescript/packages/connect/test/unit/client.test.ts
+++ b/sdks/typescript/packages/connect/test/unit/client.test.ts
@@ -19,8 +19,11 @@ import type {
     EstablishResponse,
     HealthResponse,
     InfoResponse,
+    IntrospectResponse,
+    LogoutResponse,
     RedeemResponse,
     RefreshResponse,
+    RevokeAllResponse,
     StatusPollResponse,
 } from "../../src";
 import { buildInfoResponse, makeFetch } from "../helpers/fetch";
@@ -285,6 +288,103 @@ describe("ConnectClient", () => {
 
             expect(result).toEqual(expected);
             expect(fetchMock.mock.calls[0][0]).toBe("https://connect.example.com/info");
+        });
+    });
+
+    describe("introspect", () => {
+
+        it("POSTs /introspect (no client auth) and returns the session status", async () => {
+
+            const expected: IntrospectResponse = {
+                status: "active",
+                recommendedRecheckSeconds: 30,
+            };
+            const fetchMock = makeFetch([{ ok: true, status: 200, body: expected }]);
+            const client = new ConnectClient({
+                baseUrl: "https://connect.example.com",
+                fetch: fetchMock as unknown as typeof globalThis.fetch,
+            });
+
+            const result = await client.introspect({ accessToken: "a-jwt" });
+
+            expect(result).toEqual(expected);
+            const [url, init] = fetchMock.mock.calls[0];
+            expect(url).toBe("https://connect.example.com/introspect");
+            expect(init.method).toBe("POST");
+            expect((init.headers as Record<string, string>)["Authorization"]).toBeUndefined();
+        });
+    });
+
+    describe("logout", () => {
+
+        it("POSTs /logout and returns the revocation outcome", async () => {
+
+            const expected: LogoutResponse = { revoked: true };
+            const fetchMock = makeFetch([{ ok: true, status: 200, body: expected }]);
+            const client = new ConnectClient({
+                baseUrl: "https://connect.example.com",
+                fetch: fetchMock as unknown as typeof globalThis.fetch,
+            });
+
+            const result = await client.logout({ refreshToken: "r-jwt" });
+
+            expect(result).toEqual(expected);
+            expect(fetchMock.mock.calls[0][0]).toBe("https://connect.example.com/logout");
+        });
+    });
+
+    describe("revokeAll", () => {
+
+        it("throws ConnectConfigError when clientAuth is not configured", async () => {
+
+            const client = new ConnectClient({
+                baseUrl: "https://connect.example.com",
+                fetch: makeFetch([]) as unknown as typeof globalThis.fetch,
+            });
+
+            await expect(client.revokeAll({
+                accountIdentifier: "acct-1",
+            })).rejects.toBeInstanceOf(ConnectConfigError);
+        });
+
+        it("POSTs /revoke-all with a client-auth JWT bound to the body", async () => {
+
+            const { privateKey, publicKey } = generateRsaKeyPair();
+            const expected: RevokeAllResponse = { revokedCount: 3 };
+            const fetchMock = makeFetch([{ ok: true, status: 200, body: expected }]);
+            const client = new ConnectClient({
+                baseUrl: "https://connect.example.com",
+                fetch: fetchMock as unknown as typeof globalThis.fetch,
+                clientAuth: {
+                    applicationAnchor: APPLICATION_ANCHOR,
+                    privateKeyPem: privateKey,
+                },
+            });
+
+            const result = await client.revokeAll({ accountIdentifier: "acct-1" });
+
+            expect(result).toEqual(expected);
+            const [url, init] = fetchMock.mock.calls[0];
+            expect(url).toBe("https://connect.example.com/revoke-all");
+            expect(init.method).toBe("POST");
+
+            const headers = init.headers as Record<string, string>;
+            expect(headers["Authorization"]).toMatch(new RegExp(`^${CLIENT_JWT_AUTH_SCHEME} `));
+
+            const sentBody = init.body as string;
+            expect(JSON.parse(sentBody)).toEqual({ accountIdentifier: "acct-1" });
+
+            const jwt = headers["Authorization"].slice(CLIENT_JWT_AUTH_SCHEME.length + 1);
+            const parsed = JWTToken.fromTokenOrNull<Record<string, unknown>, {
+                iss: string;
+                aud: string;
+                body_sha256: string;
+            }>(jwt);
+            expect(parsed).not.toBeNull();
+            expect(parsed!.body.iss).toBe(APPLICATION_ANCHOR);
+            expect(parsed!.body.aud).toBe(CLIENT_JWT_AUDIENCE);
+            expect(parsed!.body.body_sha256).toBe(sha256Base64(sentBody));
+            expect(parsed!.verifySignature(publicKey)).toBe(true);
         });
     });
 


### PR DESCRIPTION
Bumps the specs submodule from aee6731 to 9b89e16, picking up the
Connect API 0.2.0 changes: /introspect, /logout, and /revoke-all.

https://claude.ai/code/session_01J1XfsefNDcUdewT49KnDCV