### PR TITLE
feat: sync SDKs with spec 0.4.0/0.3.0 and make consent-gated claims optional

### DIFF
--- a/sdks/csharp/Sudomimus.slnx
+++ b/sdks/csharp/Sudomimus.slnx
@@ -6,6 +6,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Sudomimus.Connect.Tests/Sudomimus.Connect.Tests.csproj" />
+    <Project Path="tests/Sudomimus.Contract.Tests/Sudomimus.Contract.Tests.csproj" />
     <Project Path="tests/Sudomimus.Native.Tests/Sudomimus.Native.Tests.csproj" />
     <Project Path="tests/Sudomimus.Token.Tests/Sudomimus.Token.Tests.csproj" />
   </Folder>

--- a/sdks/csharp/src/Sudomimus.Connect/Schemas/AuthenticationRuleConstraint.cs
+++ b/sdks/csharp/src/Sudomimus.Connect/Schemas/AuthenticationRuleConstraint.cs
@@ -13,6 +13,8 @@ public static class AuthenticationMethod
     public const string GoogleOAuth = "GOOGLE_OAUTH";
     public const string GitHubOAuth = "GITHUB_OAUTH";
     public const string DiscordOAuth = "DISCORD_OAUTH";
+    public const string BattleNetOAuth = "BATTLENET_OAUTH";
+    public const string XOAuth = "X_OAUTH";
 }
 
 /// <summary>
@@ -45,7 +47,8 @@ public sealed record AuthenticationRuleConstraint
 ///   <item><c>STEAM_TICKET</c>: <see cref="AllowedSteamAppIds"/></item>
 ///   <item><c>GITHUB_OAUTH</c>: <see cref="AllowedGitHubOrgs"/></item>
 ///   <item><c>EMAIL_VERIFICATION</c>, <c>STEAM_OPENID</c>, <c>ACCESS_KEY_DIRECT</c>,
-///     <c>GOOGLE_OAUTH</c>, <c>DISCORD_OAUTH</c>: empty payload.</item>
+///     <c>GOOGLE_OAUTH</c>, <c>DISCORD_OAUTH</c>, <c>BATTLENET_OAUTH</c>,
+///     <c>X_OAUTH</c>: empty payload.</item>
 /// </list>
 /// </summary>
 public sealed record AuthenticationRulePayload

--- a/sdks/csharp/src/Sudomimus.Connect/Sudomimus.Connect.csproj
+++ b/sdks/csharp/src/Sudomimus.Connect/Sudomimus.Connect.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Sudomimus.Connect</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Description>HTTP client for the Sudomimus Connect API — establish authentication inquiries, poll status, redeem tokens, refresh, introspect, and revoke sessions. Mirrors the @sudomimus/connect TypeScript SDK.</Description>
     <PackageTags>sudomimus;auth;connect;jwt</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/sdks/csharp/src/Sudomimus.Token/AccessTokenBody.cs
+++ b/sdks/csharp/src/Sudomimus.Token/AccessTokenBody.cs
@@ -20,14 +20,23 @@ public sealed record AccessTokenBody
     [JsonPropertyName("subject")]
     public required string Subject { get; init; }
 
+    /// <summary>
+    /// Given name. Consent-gated (claim sharing): minted only when the
+    /// application's claim policy permits it AND the user has granted the
+    /// claim, so it may be absent even when the account has a value stored.
+    /// </summary>
     [JsonPropertyName("firstName")]
-    public required string FirstName { get; init; }
+    public string? FirstName { get; init; }
 
+    /// <summary>Family name. Same consent gating as <c>FirstName</c>.</summary>
     [JsonPropertyName("lastName")]
     public string? LastName { get; init; }
 
     /// <summary>
-    /// Verified email associated with this login, when the account owns one.
+    /// Verified email associated with this login. Consent-gated like
+    /// <c>FirstName</c> / <c>LastName</c> (minted only when policy permits AND
+    /// the user granted the EMAIL claim), and always omitted for accounts with
+    /// no verified email (e.g. Steam-only or AccessKey-only).
     /// </summary>
     [JsonPropertyName("emailAddress")]
     public string? EmailAddress { get; init; }

--- a/sdks/csharp/src/Sudomimus.Token/Sudomimus.Token.csproj
+++ b/sdks/csharp/src/Sudomimus.Token/Sudomimus.Token.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Sudomimus.Token</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Description>Parse and verify Sudomimus access and refresh JWTs (RS256). Mirrors the @sudomimus/token TypeScript SDK and the on-wire format used by Sudomimus Connect and Native APIs.</Description>
     <PackageTags>sudomimus;jwt;rs256;auth;token</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/sdks/csharp/tests/Sudomimus.Contract.Tests/ModelContractTests.cs
+++ b/sdks/csharp/tests/Sudomimus.Contract.Tests/ModelContractTests.cs
@@ -1,0 +1,132 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace Sudomimus.Contract.Tests;
+
+/// <summary>
+/// Guards the hand-written C# models against drift from the OpenAPI specs in
+/// <c>specs/</c>. The C# SDKs do not generate from the spec (the idiomatic
+/// hand-written records — <c>sealed record</c> + <c>required</c> + native
+/// <see cref="JsonPolymorphicAttribute"/> — read better than any generator's
+/// output), so these tests make the spec earn its keep as a contract oracle
+/// instead: every mapped schema's property set, required set, and string
+/// enums must match the corresponding C# type.
+///
+/// Scope: flat request/response DTOs and the token bodies, plus the string
+/// "const class" enums. The <c>oneOf</c> discriminated unions
+/// (ReturnMethodDeclaration, StatusPollResponse, the auth/realize payload
+/// unions) intentionally diverge in shape from the spec and are reviewed by
+/// hand; they are out of scope for this prototype.
+/// </summary>
+public sealed class ModelContractTests
+{
+    public static TheoryData<string, string, Type> MappedSchemas() => new()
+    {
+        // ---- Connect: token bodies (live in Sudomimus.Token) ----
+        { "connect", "AccessTokenBody", typeof(Token.AccessTokenBody) },
+        { "connect", "RefreshTokenBody", typeof(Token.RefreshTokenBody) },
+
+        // ---- Connect: flat request/response DTOs ----
+        { "connect", "HealthResponse", typeof(Connect.HealthResponse) },
+        { "connect", "EstablishRequest", typeof(Connect.EstablishRequest) },
+        { "connect", "EstablishResponse", typeof(Connect.EstablishResponse) },
+        { "connect", "StatusPollRequest", typeof(Connect.StatusPollRequest) },
+        { "connect", "RedeemRequest", typeof(Connect.RedeemRequest) },
+        { "connect", "RedeemResponse", typeof(Connect.RedeemResponse) },
+        { "connect", "RefreshRequest", typeof(Connect.RefreshRequest) },
+        { "connect", "RefreshResponse", typeof(Connect.RefreshResponse) },
+        { "connect", "InfoRequest", typeof(Connect.InfoRequest) },
+        { "connect", "InfoResponse", typeof(Connect.InfoResponse) },
+        { "connect", "IntrospectRequest", typeof(Connect.IntrospectRequest) },
+        { "connect", "IntrospectResponse", typeof(Connect.IntrospectResponse) },
+        { "connect", "LogoutRequest", typeof(Connect.LogoutRequest) },
+        { "connect", "LogoutResponse", typeof(Connect.LogoutResponse) },
+        { "connect", "RevokeAllRequest", typeof(Connect.RevokeAllRequest) },
+        { "connect", "RevokeAllResponse", typeof(Connect.RevokeAllResponse) },
+
+        // ---- Native: direct-issue DTOs ----
+        { "native", "DirectIssueAccessKeyRequest", typeof(Native.DirectIssueAccessKeyRequest) },
+        { "native", "DirectIssueAccessKeyResponse", typeof(Native.DirectIssueAccessKeyResponse) },
+        { "native", "DirectIssueSteamTicketRequest", typeof(Native.DirectIssueSteamTicketRequest) },
+        { "native", "DirectIssueSteamTicketResponse", typeof(Native.DirectIssueSteamTicketResponse) },
+    };
+
+    [Theory]
+    [MemberData(nameof(MappedSchemas))]
+    public void Model_property_set_matches_spec(string service, string schemaName, Type type)
+    {
+        var specProps = SpecDocument.Load(service).PropertyNames(schemaName);
+        var clrProps = WireProperties(type).Keys.ToHashSet();
+
+        var missingInClr = specProps.Except(clrProps).OrderBy(x => x).ToList();
+        var extraInClr = clrProps.Except(specProps).OrderBy(x => x).ToList();
+
+        Assert.True(
+            missingInClr.Count == 0 && extraInClr.Count == 0,
+            $"{type.FullName} drifted from spec schema '{schemaName}'.\n"
+                + $"  Missing in C# (present in spec): [{string.Join(", ", missingInClr)}]\n"
+                + $"  Extra in C# (absent from spec):  [{string.Join(", ", extraInClr)}]");
+    }
+
+    [Theory]
+    [MemberData(nameof(MappedSchemas))]
+    public void Model_required_set_matches_spec(string service, string schemaName, Type type)
+    {
+        var specRequired = SpecDocument.Load(service).RequiredNames(schemaName);
+        var clrRequired = WireProperties(type)
+            .Where(kv => kv.Value)
+            .Select(kv => kv.Key)
+            .ToHashSet();
+
+        var shouldBeRequired = specRequired.Except(clrRequired).OrderBy(x => x).ToList();
+        var shouldBeOptional = clrRequired.Except(specRequired).OrderBy(x => x).ToList();
+
+        Assert.True(
+            shouldBeRequired.Count == 0 && shouldBeOptional.Count == 0,
+            $"{type.FullName} required-ness drifted from spec schema '{schemaName}'.\n"
+                + $"  Spec-required but optional in C#: [{string.Join(", ", shouldBeRequired)}]\n"
+                + $"  Required in C# but optional in spec: [{string.Join(", ", shouldBeOptional)}]");
+    }
+
+    public static TheoryData<string, string, string, Type> MappedEnums() => new()
+    {
+        { "connect", "AuthenticationRuleConstraint", "method", typeof(Connect.AuthenticationMethod) },
+        { "connect", "IntrospectResponse", "status", typeof(Connect.IntrospectStatus) },
+    };
+
+    [Theory]
+    [MemberData(nameof(MappedEnums))]
+    public void Enum_values_match_spec(string service, string schemaName, string property, Type constClass)
+    {
+        var specValues = SpecDocument.Load(service).PropertyEnum(schemaName, property);
+        var clrValues = StringConstants(constClass);
+
+        var missingInClr = specValues.Except(clrValues).OrderBy(x => x).ToList();
+        var extraInClr = clrValues.Except(specValues).OrderBy(x => x).ToList();
+
+        Assert.True(
+            missingInClr.Count == 0 && extraInClr.Count == 0,
+            $"{constClass.FullName} drifted from spec enum '{schemaName}.{property}'.\n"
+                + $"  Missing in C# (present in spec): [{string.Join(", ", missingInClr)}]\n"
+                + $"  Extra in C# (absent from spec):  [{string.Join(", ", extraInClr)}]");
+    }
+
+    /// <summary>Map of wire name -> isRequired for every public instance property.</summary>
+    private static Dictionary<string, bool> WireProperties(Type type) =>
+        type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .ToDictionary(WireName, IsRequired);
+
+    private static string WireName(PropertyInfo p) =>
+        p.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? p.Name;
+
+    private static bool IsRequired(PropertyInfo p) =>
+        p.GetCustomAttribute<RequiredMemberAttribute>() is not null;
+
+    private static HashSet<string> StringConstants(Type constClass) =>
+        constClass.GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(f => f is { IsLiteral: true } && f.FieldType == typeof(string))
+            .Select(f => (string)f.GetRawConstantValue()!)
+            .ToHashSet();
+}

--- a/sdks/csharp/tests/Sudomimus.Contract.Tests/SpecDocument.cs
+++ b/sdks/csharp/tests/Sudomimus.Contract.Tests/SpecDocument.cs
@@ -1,0 +1,93 @@
+using YamlDotNet.Serialization;
+
+namespace Sudomimus.Contract.Tests;
+
+/// <summary>
+/// Thin read-only view over one OpenAPI document in <c>specs/</c>, used by the
+/// contract tests to compare the hand-written C# models against the spec that
+/// is the cross-repo source of truth. Only the handful of accessors the tests
+/// need are implemented; this is deliberately not a general OpenAPI parser.
+/// </summary>
+public sealed class SpecDocument
+{
+    private readonly IReadOnlyDictionary<object, object> _schemas;
+
+    private SpecDocument(IReadOnlyDictionary<object, object> schemas) => _schemas = schemas;
+
+    private static readonly Dictionary<string, SpecDocument> Cache = new();
+
+    /// <summary>Load <c>{service}.yaml</c> (e.g. "connect"), cached per process.</summary>
+    public static SpecDocument Load(string service)
+    {
+        if (Cache.TryGetValue(service, out var cached))
+        {
+            return cached;
+        }
+
+        var path = Path.Combine(FindSpecsDir(), $"{service}.yaml");
+        var root = new DeserializerBuilder().Build()
+            .Deserialize<Dictionary<object, object>>(File.ReadAllText(path));
+        var components = (Dictionary<object, object>)root["components"];
+        var schemas = (Dictionary<object, object>)components["schemas"];
+
+        var doc = new SpecDocument(schemas);
+        Cache[service] = doc;
+        return doc;
+    }
+
+    private Dictionary<object, object> Schema(string name)
+    {
+        if (!_schemas.TryGetValue(name, out var schema))
+        {
+            throw new InvalidOperationException($"Spec schema '{name}' not found.");
+        }
+
+        return (Dictionary<object, object>)schema;
+    }
+
+    /// <summary>The property names declared on a schema's <c>properties</c> map.</summary>
+    public IReadOnlySet<string> PropertyNames(string schemaName)
+    {
+        var schema = Schema(schemaName);
+        if (!schema.TryGetValue("properties", out var props))
+        {
+            return new HashSet<string>();
+        }
+
+        return ((Dictionary<object, object>)props).Keys.Select(k => (string)k).ToHashSet();
+    }
+
+    /// <summary>The schema's <c>required</c> list (empty when the key is absent).</summary>
+    public IReadOnlySet<string> RequiredNames(string schemaName)
+    {
+        var schema = Schema(schemaName);
+        if (!schema.TryGetValue("required", out var required))
+        {
+            return new HashSet<string>();
+        }
+
+        return ((List<object>)required).Select(v => (string)v).ToHashSet();
+    }
+
+    /// <summary>The <c>enum</c> values of a string property on a schema.</summary>
+    public IReadOnlySet<string> PropertyEnum(string schemaName, string propertyName)
+    {
+        var props = (Dictionary<object, object>)Schema(schemaName)["properties"];
+        var prop = (Dictionary<object, object>)props[propertyName];
+        return ((List<object>)prop["enum"]).Select(v => (string)v).ToHashSet();
+    }
+
+    private static string FindSpecsDir()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir is not null; dir = dir.Parent)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "specs", "connect.yaml")))
+            {
+                return Path.Combine(dir.FullName, "specs");
+            }
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate the specs/ directory by walking up from " + AppContext.BaseDirectory);
+    }
+}

--- a/sdks/csharp/tests/Sudomimus.Contract.Tests/Sudomimus.Contract.Tests.csproj
+++ b/sdks/csharp/tests/Sudomimus.Contract.Tests/Sudomimus.Contract.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RollForward>LatestMajor</RollForward>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="YamlDotNet" Version="16.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sudomimus.Connect\Sudomimus.Connect.csproj" />
+    <ProjectReference Include="..\..\src\Sudomimus.Native\Sudomimus.Native.csproj" />
+    <ProjectReference Include="..\..\src\Sudomimus.Token\Sudomimus.Token.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -1,3 +1,5 @@
 module github.com/sudomimus/sudomimus-go
 
 go 1.22
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/sdks/go/go.sum
+++ b/sdks/go/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/sdks/go/token/contract_test.go
+++ b/sdks/go/token/contract_test.go
@@ -1,0 +1,141 @@
+package token
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The Go SDK does not generate from the OpenAPI specs in specs/ (the
+// hand-written structs read better than any generator's output — see the
+// repo's contract-test rationale). These tests instead make the spec earn its
+// keep as a contract oracle: each mapped schema's field set and required set
+// must match specs/connect.yaml.
+//
+// "Required" maps to the struct tag convention used throughout this package:
+// a spec-required field carries `json:"name"` (no omitempty); a spec-optional
+// field carries `json:"name,omitempty"`.
+
+type specSchema struct {
+	Properties map[string]yaml.Node `yaml:"properties"`
+	Required   []string             `yaml:"required"`
+}
+
+type specDoc struct {
+	Components struct {
+		Schemas map[string]specSchema `yaml:"schemas"`
+	} `yaml:"components"`
+}
+
+func loadSpec(t *testing.T, service string) specDoc {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		candidate := filepath.Join(dir, "specs", service+".yaml")
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			data, readErr := os.ReadFile(candidate)
+			if readErr != nil {
+				t.Fatalf("read spec: %v", readErr)
+			}
+			var doc specDoc
+			if unmarshalErr := yaml.Unmarshal(data, &doc); unmarshalErr != nil {
+				t.Fatalf("unmarshal spec: %v", unmarshalErr)
+			}
+			return doc
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not locate specs/%s.yaml walking up from working dir", service)
+		}
+		dir = parent
+	}
+}
+
+// wireFields returns wireName -> isRequired for a struct type, where required
+// means the json tag has no `omitempty` option.
+func wireFields(t reflect.Type) map[string]bool {
+	out := map[string]bool{}
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		parts := strings.Split(tag, ",")
+		name := parts[0]
+		hasOmitempty := false
+		for _, opt := range parts[1:] {
+			if opt == "omitempty" {
+				hasOmitempty = true
+			}
+		}
+		out[name] = !hasOmitempty
+	}
+	return out
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func requiredKeys(m map[string]bool) []string {
+	out := []string{}
+	for k, req := range m {
+		if req {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestModelsMatchSpec(t *testing.T) {
+	doc := loadSpec(t, "connect")
+	cases := []struct {
+		schema string
+		typ    reflect.Type
+	}{
+		{"AccessTokenBody", reflect.TypeOf(AccessTokenBody{})},
+		{"RefreshTokenBody", reflect.TypeOf(RefreshTokenBody{})},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.schema, func(t *testing.T) {
+			schema, ok := doc.Components.Schemas[tc.schema]
+			if !ok {
+				t.Fatalf("spec schema %q not found", tc.schema)
+			}
+
+			specProps := []string{}
+			for name := range schema.Properties {
+				specProps = append(specProps, name)
+			}
+			sort.Strings(specProps)
+
+			fields := wireFields(tc.typ)
+
+			if got := keys(fields); !reflect.DeepEqual(got, specProps) {
+				t.Errorf("field set drifted from spec %q\n  spec:   %v\n  struct: %v", tc.schema, specProps, got)
+			}
+
+			specRequired := append([]string{}, schema.Required...)
+			sort.Strings(specRequired)
+			if got := requiredKeys(fields); !reflect.DeepEqual(got, specRequired) {
+				t.Errorf("required set drifted from spec %q (json `omitempty` convention)\n  spec-required:   %v\n  struct-required: %v",
+					tc.schema, specRequired, got)
+			}
+		})
+	}
+}

--- a/sdks/go/token/token_test.go
+++ b/sdks/go/token/token_test.go
@@ -99,6 +99,28 @@ func TestVerifyAccessToken_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestVerifyAccessToken_ConsentGatedClaimsAbsent(t *testing.T) {
+	// firstName / lastName / emailAddress are consent-gated and may be
+	// absent; a token carrying only `subject` must still verify.
+	keys := generateRSAKeyPair(t)
+	iat := time.Now().Unix()
+	header := map[string]any{
+		"alg": "RS256", "typ": "JWT", "iss": "sudomimus.com",
+		"aud": "anchor-1", "iat": iat, "exp": iat + 3600,
+		"jti": "access-1", "kty": "Access", "sub": "refresh-1",
+	}
+	jwt := mintToken(t, header, map[string]any{"subject": "subject-1"}, keys.privateKey)
+
+	v := NewVerifier(staticResolver(keys.publicPEM))
+	tok, err := v.VerifyAccessToken(context.Background(), jwt)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if tok.Body.Subject != "subject-1" || tok.Body.FirstName != "" || tok.Body.EmailAddress != "" {
+		t.Fatalf("unexpected body: %+v", tok.Body)
+	}
+}
+
 func TestVerifyRefreshToken_RoundTrip(t *testing.T) {
 	keys := generateRSAKeyPair(t)
 	jwt := mintRefreshToken(t, keys.privateKey, "anchor-1")
@@ -146,7 +168,7 @@ func TestVerifyAccessToken_MissingAudience(t *testing.T) {
 	keys := generateRSAKeyPair(t)
 	header := map[string]any{
 		"alg": "RS256", "typ": "JWT",
-		"iat": int64(0), "exp": int64(1<<62), "kty": "Access",
+		"iat": int64(0), "exp": int64(1 << 62), "kty": "Access",
 	}
 	body := map[string]any{"subject": "subject-1", "firstName": "Ada"}
 	jwt := mintToken(t, header, body, keys.privateKey)

--- a/sdks/go/token/types.go
+++ b/sdks/go/token/types.go
@@ -29,9 +29,13 @@ type Header struct {
 // the value an application keys its users on. The raw internal account
 // identifier never appears in a token. It is opaque: never parse or
 // format-validate it.
+//
+// FirstName, LastName, and EmailAddress are consent-gated (claim sharing):
+// each is minted only when the application's claim policy permits it AND the
+// user has granted that claim, so any of them may be absent.
 type AccessTokenBody struct {
 	Subject      string `json:"subject"`
-	FirstName    string `json:"firstName"`
+	FirstName    string `json:"firstName,omitempty"`
 	LastName     string `json:"lastName,omitempty"`
 	EmailAddress string `json:"emailAddress,omitempty"`
 }

--- a/sdks/java/build.gradle.kts
+++ b/sdks/java/build.gradle.kts
@@ -1,6 +1,6 @@
-plugins {
-    `java-library` apply false
-}
+// `java-library` is a core Gradle plugin (always on the classpath), so it is
+// not declared here with `apply false` — Gradle 8+ rejects that as an error.
+// Subprojects apply it themselves; the `subprojects` block below reacts to it.
 
 allprojects {
     group = "com.sudomimus"

--- a/sdks/java/token/build.gradle.kts
+++ b/sdks/java/token/build.gradle.kts
@@ -11,6 +11,10 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:5.11.4"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // Spec contract test: parse the OpenAPI YAML with the Jackson stack the
+    // SDK already uses. Test-only — never shipped in the published artifact.
+    testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.2")
 }
 
 publishing {

--- a/sdks/java/token/src/main/java/com/sudomimus/token/AccessTokenBody.java
+++ b/sdks/java/token/src/main/java/com/sudomimus/token/AccessTokenBody.java
@@ -13,6 +13,13 @@ public final class AccessTokenBody {
      * identifier never appears in a token. Opaque: never parse it.
      */
     @JsonProperty("subject") public String subject;
+
+    /**
+     * Given name. Consent-gated (claim sharing): minted only when the
+     * application's claim policy permits it AND the user has granted the claim,
+     * so it may be {@code null} even when the account has a value stored. The
+     * same gating applies to {@link #lastName} and {@link #emailAddress}.
+     */
     @JsonProperty("firstName") public String firstName;
     @JsonProperty("lastName") public String lastName;
     @JsonProperty("emailAddress") public String emailAddress;

--- a/sdks/java/token/src/test/java/com/sudomimus/token/SpecContractTest.java
+++ b/sdks/java/token/src/test/java/com/sudomimus/token/SpecContractTest.java
@@ -1,0 +1,77 @@
+package com.sudomimus.token;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeSet;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The Java SDK does not generate from the OpenAPI specs in {@code specs/} (the
+ * hand-written classes read better than any generator's output — running
+ * openapi-generator on these specs yields ~300-line POJOs and Gson-based oneOf
+ * machinery). These tests instead make the spec earn its keep as a contract
+ * oracle: each mapped schema's property set must match {@code specs/connect.yaml}.
+ *
+ * <p>Required-ness is not asserted here: the hand-written classes model claims
+ * as plain nullable fields (Jackson leaves absent claims null), so there is no
+ * required marker to compare against. The field-set check still catches the
+ * high-value drift — a property added to or removed from the spec.
+ */
+final class SpecContractTest {
+
+    private static JsonNode loadSchemas(String service) throws Exception {
+        File dir = new File("").getAbsoluteFile();
+        while (dir != null) {
+            File candidate = new File(dir, "specs/" + service + ".yaml");
+            if (candidate.isFile()) {
+                JsonNode root = new ObjectMapper(new YAMLFactory()).readTree(candidate);
+                return root.path("components").path("schemas");
+            }
+            dir = dir.getParentFile();
+        }
+        throw new IllegalStateException("Could not locate specs/" + service + ".yaml");
+    }
+
+    private static TreeSet<String> specProperties(JsonNode schemas, String schemaName) {
+        JsonNode props = schemas.path(schemaName).path("properties");
+        TreeSet<String> names = new TreeSet<>();
+        for (Iterator<String> it = props.fieldNames(); it.hasNext(); ) {
+            names.add(it.next());
+        }
+        return names;
+    }
+
+    private static TreeSet<String> wireFields(Class<?> type) {
+        TreeSet<String> names = new TreeSet<>();
+        for (Field f : type.getDeclaredFields()) {
+            JsonProperty ann = f.getAnnotation(JsonProperty.class);
+            names.add(ann != null ? ann.value() : f.getName());
+        }
+        return names;
+    }
+
+    @Test
+    void modelsMatchSpec() throws Exception {
+        JsonNode schemas = loadSchemas("connect");
+        Map<String, Class<?>> mapping =
+                Map.of(
+                        "AccessTokenBody", AccessTokenBody.class,
+                        "RefreshTokenBody", RefreshTokenBody.class);
+
+        for (Map.Entry<String, Class<?>> entry : mapping.entrySet()) {
+            assertEquals(
+                    specProperties(schemas, entry.getKey()),
+                    wireFields(entry.getValue()),
+                    "Field set of " + entry.getValue().getName() + " drifted from spec schema '"
+                            + entry.getKey() + "'");
+        }
+    }
+}

--- a/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/_generated/models.py
+++ b/sdks/python/packages/sudomimus-connect/src/sudomimus_connect/_generated/models.py
@@ -60,8 +60,14 @@ class RedeemRequest(BaseModel):
 
 class RedeemResponse(BaseModel):
     applicationAnchor: str
-    refreshToken: str = Field(..., description="Long-lived refresh token (JWT).")
-    accessToken: str = Field(..., description="Short-lived access token (JWT).")
+    refreshToken: str = Field(
+        ...,
+        description="Long-lived refresh token (JWT). Decode its body to\n`RefreshTokenBody` (see schema). The refresh token leaves the\nsystem, so its body carries the sector `subject`, never the\ninternal account identifier.\n",
+    )
+    accessToken: str = Field(
+        ...,
+        description="Short-lived access token (JWT). Decode its body to\n`AccessTokenBody` (see schema) — the application-visible user\nkey is the `subject` (sector subject) claim.\n",
+    )
 
 
 class RefreshRequest(BaseModel):
@@ -69,15 +75,59 @@ class RefreshRequest(BaseModel):
 
 
 class RefreshResponse(BaseModel):
-    accessToken: str = Field(..., description="Short-lived access token (JWT).")
+    accessToken: str = Field(
+        ...,
+        description="Short-lived access token (JWT). Decode its body to\n`AccessTokenBody` (see schema) — the application-visible user\nkey is the `subject` (sector subject) claim.\n",
+    )
     refreshToken: str = Field(
         ...,
-        description=(
-            "Newly issued refresh token (JWT). The presented refresh token is "
-            "invalidated atomically as part of the same call; re-presenting it "
-            "is treated as compromise under OAuth 2.1 BCP §4.14.2 strict "
-            "rotation."
-        ),
+        description="Newly issued refresh token (JWT); body is `RefreshTokenBody`.\nThe presented refresh token is invalidated atomically as part\nof the same call; re-presenting it is treated as compromise\nunder OAuth 2.1 BCP §4.14.2 strict rotation.\n",
+    )
+
+
+class AccessTokenBody(BaseModel):
+    """
+    Decoded body (payload) of a Sudomimus access token. The standard
+    JWT envelope claims (`iss`, `aud`, `iat`, `exp`, `jti`, `kty`,
+    `sub`) live in the JWT *header*; this object is the body. The
+    application keys its users on `subject`. The `firstName`,
+    `lastName`, and `emailAddress` claims are consent-gated (claim
+    sharing): each is minted only when the application's claim policy
+    permits it AND the user has granted that claim, so any of them may
+    be absent.
+
+    """
+
+    subject: str = Field(
+        ...,
+        description="The application-visible user identifier — the per-(account,\nsector) **sector subject**, also the OIDC `sub`. This is the\nvalue an application keys its users on; the raw internal\naccount identifier never appears in a token. User-rotatable.\nOpaque: never parse or format-validate it.\n",
+    )
+    firstName: str | None = Field(
+        None,
+        description="Given name. Minted only when the application's claim policy\npermits it AND the user has granted the claim; may be absent\neven when the account has a value stored.\n",
+    )
+    lastName: str | None = Field(
+        None, description="Family name. Same consent gating as `firstName`.\n"
+    )
+    emailAddress: str | None = Field(
+        None,
+        description="Verified email associated with this login. Consent-gated like\n`firstName` / `lastName` (minted only when policy permits AND\nthe user granted the EMAIL claim). When included: the exact\nemail typed for email-OTP logins, otherwise the account's\nprimary email. Always omitted for accounts with no verified\nemail (e.g. Steam-only or AccessKey-only).\n",
+    )
+
+
+class RefreshTokenBody(BaseModel):
+    """
+    Decoded body (payload) of a Sudomimus refresh token. Carries the
+    sector `subject` (the same pairwise identifier as the access-token
+    body) because the refresh token leaves the system and must never
+    expose the internal account identifier. Informational only —
+    `/refresh` resolves the token by its `jti`, not by reading the body.
+
+    """
+
+    subject: str = Field(
+        ...,
+        description="The application-visible **sector subject**. Opaque: never\nparse or format-validate it.\n",
     )
 
 
@@ -145,7 +195,7 @@ class LogoutResponse(BaseModel):
 class RevokeAllRequest(BaseModel):
     subject: str = Field(
         ...,
-        description="The sector subject the application sees for the user (the access / id token `sub`). Reverse-mapped server-side to the underlying account; a subject the application has never been issued (or one from another sector) revokes nothing.",
+        description="The sector subject the application sees for the user (the access / id token `sub`). Reverse-mapped server-side to the underlying account, whose sessions are then revoked for the calling application. A subject the application has never been issued (or one from another sector) revokes nothing.",
     )
 
 
@@ -162,11 +212,36 @@ class Method(StrEnum):
 
     PASSKEY = "PASSKEY"
     EMAIL_VERIFICATION = "EMAIL_VERIFICATION"
+    STEAM_TICKET = "STEAM_TICKET"
+    STEAM_OPENID = "STEAM_OPENID"
+    ACCESS_KEY_DIRECT = "ACCESS_KEY_DIRECT"
+    GOOGLE_OAUTH = "GOOGLE_OAUTH"
+    GITHUB_OAUTH = "GITHUB_OAUTH"
+    DISCORD_OAUTH = "DISCORD_OAUTH"
+    BATTLENET_OAUTH = "BATTLENET_OAUTH"
+    X_OAUTH = "X_OAUTH"
 
 
 class AuthenticationRulePasskeyPayload(BaseModel):
     """
-    Empty payload — passkey constraints carry no further parameters.
+    Passkey-method payload. `allowUsernameless` opts the application
+    in to discoverable-credential ("usernameless") passkey login,
+    where the user authenticates without first entering an email.
+    Absent or `false` keeps the email-first flow; only the entry
+    path is affected — realize authorization is still decided
+    entirely by Layer 2.
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    allowUsernameless: bool | None = None
+
+
+class AuthenticationRuleEmailVerificationPayload(BaseModel):
+    """
+    Empty payload — email-verification constraints carry no further parameters.
     """
 
     model_config = ConfigDict(
@@ -174,9 +249,123 @@ class AuthenticationRulePasskeyPayload(BaseModel):
     )
 
 
-class AuthenticationRuleEmailVerificationPayload(BaseModel):
+class AllowedSteamAppId(RootModel[int]):
+    root: int = Field(..., ge=1)
+
+
+class AuthenticationRuleSteamTicketPayload(BaseModel):
     """
-    Empty payload — email-verification constraints carry no further parameters.
+    Steam-native-ticket payload. Gates native-api's
+    `/direct-issue/steam-ticket` flow. `allowedSteamAppIds` is the
+    non-empty list of Steam App IDs whose tickets are accepted.
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    allowedSteamAppIds: list[AllowedSteamAppId] = Field(..., min_length=1)
+
+
+class AuthenticationRuleSteamOpenIdPayload(BaseModel):
+    """
+    Steam OpenID 2.0 carries no app-id concept (that is
+    native-ticket-specific). Any Steam account is accepted as long
+    as the application's rule set allows STEAM_OPENID at all.
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+
+
+class AuthenticationRuleAccessKeyDirectPayload(BaseModel):
+    """
+    Gates native-api's `/direct-issue/access-key` flow. Credentials
+    live in the dedicated `AccessKeyCredential` table; no row of
+    this method ever appears in the `Authentication` table.
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+
+
+class AuthenticationRuleGoogleOAuthPayload(BaseModel):
+    """
+    Phase 1: any Google account is accepted as long as the
+    application's rule set allows GOOGLE_OAUTH at all. A later
+    phase will add `allowedHostedDomains: string[]` for Google
+    Workspace gating.
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+
+
+class AllowedGitHubOrg(RootModel[str]):
+    root: str = Field(..., min_length=1)
+
+
+class AuthenticationRuleGitHubOAuthPayload(BaseModel):
+    """
+    Empty `allowedGitHubOrgs` array means no org gating — any
+    GitHub account is accepted. Non-empty means the user must be a
+    member of at least one listed organization (case-insensitive
+    match on the org `login`). The `read:org` OAuth scope is only
+    requested when at least one matching rule carries a non-empty
+    allowlist; applications without org gating keep the minimal
+    `read:user user:email` consent screen.
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    allowedGitHubOrgs: list[AllowedGitHubOrg]
+
+
+class AuthenticationRuleDiscordOAuthPayload(BaseModel):
+    """
+    Phase 1: any Discord account is accepted as long as the
+    application's rule set allows DISCORD_OAUTH at all. Phase 1.5
+    will add `allowedDiscordGuilds: string[]` for guild (server)
+    gating, which will additionally request the `guilds` OAuth
+    scope and fetch `GET /users/@me/guilds`.
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+
+
+class AuthenticationRuleBattleNetOAuthPayload(BaseModel):
+    """
+    Battle.net (Blizzard) has no per-application gating concept, so any
+    Battle.net account is accepted as long as the application's rule set
+    allows BATTLENET_OAUTH at all. Empty payload. Battle.net is an
+    email-less provider, so Layer-2 EMAIL rules fail closed against a
+    Battle.net-only account.
+
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+
+
+class AuthenticationRuleXOAuthPayload(BaseModel):
+    """
+    X (formerly Twitter) has no per-application gating concept, so any
+    X account is accepted as long as the application's rule set allows
+    X_OAUTH at all. Empty payload. X is an email-less provider, so
+    Layer-2 EMAIL rules fail closed against an X-only account.
+
     """
 
     model_config = ConfigDict(
@@ -202,25 +391,57 @@ class RealizeRuleEmailPayload(BaseModel):
     )
 
 
+class AllowedSteamId(RootModel[str]):
+    root: str = Field(..., pattern="^(\\*|[0-9]{1,20})$")
+
+
 class RealizeRuleSteamIdPayload(BaseModel):
-    allowedSteamIds: list[str] = Field(
-        ...,
-        description='Per-realize-time check against the realized account\'s SteamID64.\nEach entry is either the literal "*" (wildcard) or a decimal SteamID64 string.\n',
-    )
+    """
+    Per-realize-time check against the realized account's SteamID64.
+    Each entry is either the literal `"*"` (wildcard, allow any
+    Steam identity) or a decimal SteamID64 string.
+
+    """
+
+    allowedSteamIds: list[AllowedSteamId]
+
+
+class AllowedAccountAliase(RootModel[str]):
+    root: str = Field(..., max_length=128, min_length=1)
 
 
 class RealizeRuleAccountAliasPayload(BaseModel):
-    allowedAccountAliases: list[str] = Field(
-        ...,
-        description="Exact match on the realizing account's account alias — the user-visible, application-invisible, rotatable handle. No wildcard. Opaque: never parsed or format-validated.",
-    )
+    """
+    Exact match on the realizing account's **account alias** — the
+    user-visible, application-invisible, rotatable handle the user
+    reads in the With portal and shares out-of-band with whoever
+    configures the rule. No wildcard — because the account does not
+    yet exist during fresh registration, this constraint matches
+    nothing for new sign-ups. The alias is opaque: it is compared by
+    exact-string equality and never parsed or format-validated.
+
+    """
+
+    allowedAccountAliases: list[AllowedAccountAliase]
+
+
+class AllowedSectorSubject(RootModel[str]):
+    root: str = Field(..., max_length=128, min_length=1)
 
 
 class RealizeRuleSectorSubjectPayload(BaseModel):
-    allowedSectorSubjects: list[str] = Field(
-        ...,
-        description="Exact match on the realizing account's sector subject for the application's sector (the application-visible token `sub`). No wildcard. Opaque: never parsed or format-validated.",
-    )
+    """
+    Exact match on the realizing account's **sector subject** for the
+    realizing application's sector — the application-visible token
+    `sub` the owner already sees in their own logs. No wildcard.
+    Rotating the subject locks the user out (it becomes a brand-new,
+    not-yet-allow-listed identity) rather than letting them bypass the
+    rule. The subject is opaque: compared by exact-string equality and
+    never parsed or format-validated.
+
+    """
+
+    allowedSectorSubjects: list[AllowedSectorSubject]
 
 
 class Type(StrEnum):
@@ -258,7 +479,32 @@ class Type2(StrEnum):
 class ReturnMethodReveal(BaseModel):
     type: Literal["REVEAL"]
     payload: dict[str, Any] = Field(
-        ..., description="Empty payload — REVEAL surfaces tokens directly in the UI."
+        ...,
+        description="Empty payload. Tokens are surfaced directly in the UI at\nrealize time and the inquiry is marked redeemed immediately;\nany subsequent `/redeem` for the same inquiry fails with\n`InquiryAlreadyRedeemed`.\n",
+    )
+
+
+class Type3(StrEnum):
+    DIRECT_ISSUE = "DIRECT_ISSUE"
+
+
+class ReturnMethodDirectIssue(BaseModel):
+    type: Literal["DIRECT_ISSUE"]
+    payload: dict[str, Any] = Field(
+        ...,
+        description="Empty payload. Opts the application in to native-api's\ndirect-issue flows (`/direct-issue/steam-ticket`,\n`/direct-issue/access-key`). Per-inquiry payload is empty\nbecause direct-issue does not flow through `/establish`.\n",
+    )
+
+
+class Type4(StrEnum):
+    OIDC = "OIDC"
+
+
+class ReturnMethodOidc(BaseModel):
+    type: Literal["OIDC"]
+    payload: dict[str, Any] = Field(
+        ...,
+        description="Accepted on the wire for symmetry, but in practice OIDC is\nnot declared per-inquiry — the OIDC API drives its own\ninquiry against Connect via CALLBACK-to-self. The matching\nper-inquiry payload is therefore empty.\n",
     )
 
 
@@ -287,7 +533,16 @@ class AuthenticationRuleConstraint(BaseModel):
         ..., description="Which authentication method this constraint narrows to."
     )
     payload: (
-        AuthenticationRulePasskeyPayload | AuthenticationRuleEmailVerificationPayload
+        AuthenticationRulePasskeyPayload
+        | AuthenticationRuleEmailVerificationPayload
+        | AuthenticationRuleSteamTicketPayload
+        | AuthenticationRuleSteamOpenIdPayload
+        | AuthenticationRuleAccessKeyDirectPayload
+        | AuthenticationRuleGoogleOAuthPayload
+        | AuthenticationRuleGitHubOAuthPayload
+        | AuthenticationRuleDiscordOAuthPayload
+        | AuthenticationRuleBattleNetOAuthPayload
+        | AuthenticationRuleXOAuthPayload
     )
     accessTokenTtlSeconds: int | None = Field(
         None,
@@ -320,11 +575,21 @@ class RealizeRuleConstraint(BaseModel):
 
 
 class ReturnMethodDeclaration(
-    RootModel[ReturnMethodCallback | ReturnMethodStatusPoll | ReturnMethodReveal]
+    RootModel[
+        ReturnMethodCallback
+        | ReturnMethodStatusPoll
+        | ReturnMethodReveal
+        | ReturnMethodDirectIssue
+        | ReturnMethodOidc
+    ]
 ):
-    root: ReturnMethodCallback | ReturnMethodStatusPoll | ReturnMethodReveal = Field(
-        ..., discriminator="type"
-    )
+    root: (
+        ReturnMethodCallback
+        | ReturnMethodStatusPoll
+        | ReturnMethodReveal
+        | ReturnMethodDirectIssue
+        | ReturnMethodOidc
+    ) = Field(..., discriminator="type")
 
 
 class EstablishRequest(BaseModel):

--- a/sdks/python/packages/sudomimus-connect/tests/test_rotating.py
+++ b/sdks/python/packages/sudomimus-connect/tests/test_rotating.py
@@ -85,7 +85,9 @@ def test_async_in_memory_store_round_trip() -> None:
 
 
 def test_rotating_refresh_without_seed_raises() -> None:
-    rotating = RotatingConnectClient(_sync_client(lambda r: httpx.Response(404)), InMemoryTokenStore())
+    rotating = RotatingConnectClient(
+        _sync_client(lambda r: httpx.Response(404)), InMemoryTokenStore()
+    )
     with pytest.raises(ConnectConfigError):
         rotating.refresh()
 

--- a/sdks/python/packages/sudomimus-native/src/sudomimus_native/_generated/models.py
+++ b/sdks/python/packages/sudomimus-native/src/sudomimus_native/_generated/models.py
@@ -6,6 +6,12 @@ from __future__ import annotations
 from pydantic import BaseModel, Field
 
 
+class HealthResponse(BaseModel):
+    ready: bool
+    service: str
+    version: str
+
+
 class DirectIssueAccessKeyRequest(BaseModel):
     applicationAnchor: str = Field(
         ..., description="Public anchor identifying the integrating application."
@@ -24,7 +30,7 @@ class DirectIssueAccessKeyResponse(BaseModel):
     applicationAnchor: str
     accessToken: str = Field(
         ...,
-        description="Short-lived access token (JWT). Body shape matches the Connect SDK's access token.",
+        description="Short-lived access token (JWT). Body shape matches Connect's\n`AccessTokenBody`: the application-visible user key is the\n`subject` (sector subject) claim, not a raw account identifier.\nThe `firstName` / `lastName` / `emailAddress` claims are\nconsent-gated and may be absent (see Connect `AccessTokenBody`).\n",
     )
     refreshToken: str = Field(
         ...,
@@ -51,7 +57,7 @@ class DirectIssueSteamTicketResponse(BaseModel):
     applicationAnchor: str
     accessToken: str = Field(
         ...,
-        description="Short-lived access token (JWT). Body shape matches the Connect SDK's access token.",
+        description="Short-lived access token (JWT). Body shape matches Connect's\n`AccessTokenBody`: the application-visible user key is the\n`subject` (sector subject) claim, not a raw account identifier.\nThe `firstName` / `lastName` / `emailAddress` claims are\nconsent-gated and may be absent (see Connect `AccessTokenBody`).\n",
     )
     refreshToken: str = Field(
         ...,

--- a/sdks/python/packages/sudomimus-token/src/sudomimus_token/models.py
+++ b/sdks/python/packages/sudomimus-token/src/sudomimus_token/models.py
@@ -34,10 +34,15 @@ class AccessTokenBody(BaseModel):
     OIDC ``sub``) — the value an application keys its users on. The raw
     internal account identifier never appears in a token. Opaque: never
     parse or format-validate it.
+
+    ``firstName``, ``lastName``, and ``emailAddress`` are consent-gated
+    (claim sharing): each is minted only when the application's claim
+    policy permits it AND the user has granted that claim, so any of them
+    may be absent.
     """
 
     subject: str
-    firstName: str
+    firstName: str | None = None
     lastName: str | None = None
     emailAddress: str | None = None
 

--- a/sdks/python/packages/sudomimus-token/tests/test_token.py
+++ b/sdks/python/packages/sudomimus-token/tests/test_token.py
@@ -70,6 +70,18 @@ def test_verify_access_token_happy_path() -> None:
     assert token.header.aud == ANCHOR
 
 
+def test_verify_access_token_consent_gated_claims_absent() -> None:
+    # firstName / lastName / emailAddress are consent-gated and may be absent;
+    # a token carrying only `subject` must still parse.
+    private_pem, public_pem = _keypair()
+    jwt = _mint(private_pem, body={"subject": "subject-1"})
+    token = TokenVerifier(lambda _: public_pem).verify_access_token(jwt)
+    assert token.body.subject == "subject-1"
+    assert token.body.firstName is None
+    assert token.body.lastName is None
+    assert token.body.emailAddress is None
+
+
 def test_verify_refresh_token_happy_path() -> None:
     private_pem, public_pem = _keypair()
     jwt = _mint(private_pem, kty="Refresh")

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -1034,7 +1034,7 @@ wheels = [
 
 [[package]]
 name = "sudomimus-connect"
-version = "0.0.1"
+version = "1.0.0"
 source = { editable = "packages/sudomimus-connect" }
 dependencies = [
     { name = "httpx" },

--- a/sdks/typescript/packages/connect/src/_generated/schema.ts
+++ b/sdks/typescript/packages/connect/src/_generated/schema.ts
@@ -318,7 +318,11 @@ export interface components {
         /** @description Decoded body (payload) of a Sudomimus access token. The standard
          *     JWT envelope claims (`iss`, `aud`, `iat`, `exp`, `jti`, `kty`,
          *     `sub`) live in the JWT *header*; this object is the body. The
-         *     application keys its users on `subject`.
+         *     application keys its users on `subject`. The `firstName`,
+         *     `lastName`, and `emailAddress` claims are consent-gated (claim
+         *     sharing): each is minted only when the application's claim policy
+         *     permits it AND the user has granted that claim, so any of them may
+         *     be absent.
          *      */
         AccessTokenBody: {
             /** @description The application-visible user identifier — the per-(account,
@@ -328,13 +332,20 @@ export interface components {
              *     Opaque: never parse or format-validate it.
              *      */
             subject: string;
-            firstName: string;
+            /** @description Given name. Minted only when the application's claim policy
+             *     permits it AND the user has granted the claim; may be absent
+             *     even when the account has a value stored.
+             *      */
+            firstName?: string;
+            /** @description Family name. Same consent gating as `firstName`.
+             *      */
             lastName?: string;
-            /** @description Verified email associated with this login. Present only when
-             *     the account owns a verified email: the exact email typed for
-             *     email-OTP logins, otherwise the account's primary email.
-             *     Omitted for accounts with no verified email (e.g. Steam-only
-             *     or AccessKey-only).
+            /** @description Verified email associated with this login. Consent-gated like
+             *     `firstName` / `lastName` (minted only when policy permits AND
+             *     the user granted the EMAIL claim). When included: the exact
+             *     email typed for email-OTP logins, otherwise the account's
+             *     primary email. Always omitted for accounts with no verified
+             *     email (e.g. Steam-only or AccessKey-only).
              *      */
             emailAddress?: string;
         };
@@ -398,8 +409,8 @@ export interface components {
              * @description Which authentication method this constraint narrows to.
              * @enum {string}
              */
-            method: "PASSKEY" | "EMAIL_VERIFICATION" | "STEAM_TICKET" | "STEAM_OPENID" | "ACCESS_KEY_DIRECT" | "GOOGLE_OAUTH" | "GITHUB_OAUTH" | "DISCORD_OAUTH";
-            payload: components["schemas"]["AuthenticationRulePasskeyPayload"] | components["schemas"]["AuthenticationRuleEmailVerificationPayload"] | components["schemas"]["AuthenticationRuleSteamTicketPayload"] | components["schemas"]["AuthenticationRuleSteamOpenIdPayload"] | components["schemas"]["AuthenticationRuleAccessKeyDirectPayload"] | components["schemas"]["AuthenticationRuleGoogleOAuthPayload"] | components["schemas"]["AuthenticationRuleGitHubOAuthPayload"] | components["schemas"]["AuthenticationRuleDiscordOAuthPayload"];
+            method: "PASSKEY" | "EMAIL_VERIFICATION" | "STEAM_TICKET" | "STEAM_OPENID" | "ACCESS_KEY_DIRECT" | "GOOGLE_OAUTH" | "GITHUB_OAUTH" | "DISCORD_OAUTH" | "BATTLENET_OAUTH" | "X_OAUTH";
+            payload: components["schemas"]["AuthenticationRulePasskeyPayload"] | components["schemas"]["AuthenticationRuleEmailVerificationPayload"] | components["schemas"]["AuthenticationRuleSteamTicketPayload"] | components["schemas"]["AuthenticationRuleSteamOpenIdPayload"] | components["schemas"]["AuthenticationRuleAccessKeyDirectPayload"] | components["schemas"]["AuthenticationRuleGoogleOAuthPayload"] | components["schemas"]["AuthenticationRuleGitHubOAuthPayload"] | components["schemas"]["AuthenticationRuleDiscordOAuthPayload"] | components["schemas"]["AuthenticationRuleBattleNetOAuthPayload"] | components["schemas"]["AuthenticationRuleXOAuthPayload"];
             /** @description Per-constraint override for access token lifetime. Resolved at realize time. */
             accessTokenTtlSeconds?: number;
             /** @description Per-constraint override for refresh token lifetime. Resolved at realize time. */
@@ -458,6 +469,19 @@ export interface components {
          *     scope and fetch `GET /users/@me/guilds`.
          *      */
         AuthenticationRuleDiscordOAuthPayload: Record<string, never>;
+        /** @description Battle.net (Blizzard) has no per-application gating concept, so any
+         *     Battle.net account is accepted as long as the application's rule set
+         *     allows BATTLENET_OAUTH at all. Empty payload. Battle.net is an
+         *     email-less provider, so Layer-2 EMAIL rules fail closed against a
+         *     Battle.net-only account.
+         *      */
+        AuthenticationRuleBattleNetOAuthPayload: Record<string, never>;
+        /** @description X (formerly Twitter) has no per-application gating concept, so any
+         *     X account is accepted as long as the application's rule set allows
+         *     X_OAUTH at all. Empty payload. X is an email-less provider, so
+         *     Layer-2 EMAIL rules fail closed against an X-only account.
+         *      */
+        AuthenticationRuleXOAuthPayload: Record<string, never>;
         RealizeRuleConstraint: {
             /**
              * @description Which realize-rule kind this constraint narrows to.
@@ -719,6 +743,8 @@ export interface operations {
              *     - `InquiryNotFound` — the `(exposureKey, hiddenKey,
              *       confirmationKey)` triple does not resolve to a realized
              *       inquiry.
+             *     - `InquiryExpired` — the inquiry resolved but its lifetime has
+             *       elapsed (expired by TTL or out of polling attempts).
              *     - `InquiryNotRealized` — the inquiry exists but has not been
              *       realized yet.
              *     - `InquiryAlreadyRedeemed` — the inquiry has already been
@@ -734,8 +760,16 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
-            /** @description Application has been disabled via the admin kill switch.
-             *     Reason `ApplicationDisabled`.
+            /** @description The attempt was refused. The `reason` distinguishes:
+             *
+             *     - `ApplicationDisabled` — the application has been disabled
+             *       via the admin kill switch.
+             *     - `AccountDisabled` — the realizing account is disabled.
+             *     - `AccountDeleted` — the realizing account has been erased.
+             *     - `ClaimConsentRequired` — the application requires a claim
+             *       (email / first name / last name) the user has not granted;
+             *       the standing grant must be (re)established through an
+             *       interactive browser login before tokens can be issued.
              *      */
             403: {
                 headers: {
@@ -778,6 +812,17 @@ export interface operations {
                     "application/json": components["schemas"]["RefreshResponse"];
                 };
             };
+            /** @description Reason `AccountNotFound` — the account behind the refresh token
+             *     could not be resolved.
+             *      */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Refresh token rejected. The `reason` distinguishes:
              *
              *     - `RefreshTokenNotFound` — token cannot be resolved (unknown
@@ -793,6 +838,24 @@ export interface operations {
              *       also treated as compromise and the family is revoked.
              *      */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The attempt was refused. The `reason` distinguishes:
+             *
+             *     - `AccountDisabled` — the account behind the refresh token is
+             *       disabled.
+             *     - `AccountDeleted` — the account has been erased.
+             *     - `ClaimConsentRequired` — a REQUIRED claim is no longer
+             *       satisfied by a standing grant (e.g. the user revoked it); the
+             *       grant must be re-established through an interactive browser
+             *       login.
+             *      */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/sdks/typescript/packages/native/src/_generated/schema.ts
+++ b/sdks/typescript/packages/native/src/_generated/schema.ts
@@ -46,9 +46,9 @@ export interface paths {
          *          named in `applicationAnchor`, is not revoked, and has not
          *          expired.
          *       4. Timing-safe-verifies `accessKeySecret`.
-         *       5. Validates the realize-rule layer (`STEAM_ID` / `EMAIL` /
-         *          `ACCOUNT_IDENTIFIER`) and ensures a `DIRECT_ISSUE` return
-         *          rule exists.
+         *       5. Validates the realize-rule layer (`EMAIL` / `STEAM_ID` /
+         *          `ACCOUNT_ALIAS` / `SECTOR_SUBJECT`) and ensures a
+         *          `DIRECT_ISSUE` return rule exists.
          *       6. Issues access + refresh JWTs and best-effort touches the
          *          credential's `lastUsedAt` timestamp.
          *
@@ -90,8 +90,9 @@ export interface paths {
          *       3. Verifies the ticket with Steam's
          *          `ISteamUserAuth/AuthenticateUserTicket` endpoint, identity
          *          `"sudomimus"`.
-         *       4. Validates the application's realize-rule layer (`STEAM_ID` /
-         *          `EMAIL`) and ensures a `DIRECT_ISSUE` return rule exists.
+         *       4. Validates the application's realize-rule layer (`EMAIL` /
+         *          `STEAM_ID` / `ACCOUNT_ALIAS` / `SECTOR_SUBJECT`) and ensures a
+         *          `DIRECT_ISSUE` return rule exists.
          *       5. Issues access + refresh JWTs signed with the application's
          *          private key.
          *
@@ -139,6 +140,8 @@ export interface components {
             /** @description Short-lived access token (JWT). Body shape matches Connect's
              *     `AccessTokenBody`: the application-visible user key is the
              *     `subject` (sector subject) claim, not a raw account identifier.
+             *     The `firstName` / `lastName` / `emailAddress` claims are
+             *     consent-gated and may be absent (see Connect `AccessTokenBody`).
              *      */
             accessToken: string;
             /** @description Long-lived refresh token (JWT). Use Connect's `/refresh` for renewal without re-presenting the access key. */
@@ -168,6 +171,8 @@ export interface components {
             /** @description Short-lived access token (JWT). Body shape matches Connect's
              *     `AccessTokenBody`: the application-visible user key is the
              *     `subject` (sector subject) claim, not a raw account identifier.
+             *     The `firstName` / `lastName` / `emailAddress` claims are
+             *     consent-gated and may be absent (see Connect `AccessTokenBody`).
              *      */
             accessToken: string;
             /** @description Long-lived refresh token (JWT). Use Connect's `/refresh` to obtain a new access token without re-acquiring a Steam ticket. */
@@ -264,6 +269,12 @@ export interface operations {
              *       (which layer is indicated by the reason code).
              *     - `ApplicationDisabled` — the application has been disabled
              *       via the admin kill switch.
+             *     - `AccountDisabled` — the resolved account is disabled.
+             *     - `AccountDeleted` — the resolved account has been erased.
+             *     - `ClaimConsentRequired` — the application requires a claim the
+             *       user has not granted through an interactive browser login;
+             *       direct-issue cannot prompt, so it can only consume a grant
+             *       established earlier.
              *      */
             403: {
                 headers: {
@@ -351,6 +362,12 @@ export interface operations {
              *       (which layer is indicated by the reason code).
              *     - `ApplicationDisabled` — the application has been disabled
              *       via the admin kill switch.
+             *     - `AccountDisabled` — the resolved account is disabled.
+             *     - `AccountDeleted` — the resolved account has been erased.
+             *     - `ClaimConsentRequired` — the application requires a claim the
+             *       user has not granted through an interactive browser login;
+             *       direct-issue cannot prompt, so it can only consume a grant
+             *       established earlier.
              *      */
             403: {
                 headers: {

--- a/sdks/typescript/packages/token/package.json
+++ b/sdks/typescript/packages/token/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sudomimus/token",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Sudomimus Token SDK — parse and verify Sudomimus access and refresh JWTs.",
     "license": "MIT",
     "repository": {

--- a/sdks/typescript/packages/token/src/declare.ts
+++ b/sdks/typescript/packages/token/src/declare.ts
@@ -19,14 +19,25 @@ export type AccessTokenBody = {
      * format-validate it.
      */
     readonly subject: string;
-    readonly firstName: string;
+
+    /**
+     * Given name. Consent-gated (claim sharing): minted only when the
+     * application's claim policy permits it AND the user has granted the
+     * claim, so it may be absent even when the account has a value stored.
+     */
+    readonly firstName?: string;
+
+    /**
+     * Family name. Same consent gating as `firstName`.
+     */
     readonly lastName?: string;
 
     /**
-     * Verified email associated with this login. Present only when the
-     * account owns a verified email: the exact email typed for email-OTP
-     * logins, otherwise the account's primary email. Omitted for accounts
-     * with no verified email (e.g. Steam-only or AccessKey-only).
+     * Verified email associated with this login. Consent-gated like
+     * `firstName` / `lastName` (minted only when policy permits AND the user
+     * granted the EMAIL claim). When included: the exact email typed for
+     * email-OTP logins, otherwise the account's primary email. Always omitted
+     * for accounts with no verified email (e.g. Steam-only or AccessKey-only).
      */
     readonly emailAddress?: string;
 };

--- a/sdks/typescript/packages/token/test/helpers/jwt.ts
+++ b/sdks/typescript/packages/token/test/helpers/jwt.ts
@@ -29,7 +29,12 @@ export const generateRsaKeyPair = (): { privateKey: string; publicKey: string } 
 
 export const mintAccessToken = (
     privateKey: string,
-    overrides: { expirationAt?: Date; keyType?: string; audience?: string } = {},
+    overrides: {
+        expirationAt?: Date;
+        keyType?: string;
+        audience?: string;
+        body?: AccessTokenBody;
+    } = {},
 ): string => {
 
     const creator: JWTCreator<AccessTokenHeader, AccessTokenBody> =
@@ -47,7 +52,7 @@ export const mintAccessToken = (
         audience: overrides.audience ?? APPLICATION_ANCHOR,
         subject: "refresh-1",
         header: {},
-        body: {
+        body: overrides.body ?? {
             subject: "subject-1",
             firstName: "Ada",
             lastName: "Lovelace",

--- a/sdks/typescript/packages/token/test/unit/parse.test.ts
+++ b/sdks/typescript/packages/token/test/unit/parse.test.ts
@@ -32,6 +32,25 @@ describe("parseAccessToken", () => {
         expect(parsed.header.kty).toBe("Access");
         expect(parsed.header.aud).toBe(APPLICATION_ANCHOR);
     });
+
+    it("parses a token whose consent-gated claims are absent", () => {
+
+        // firstName / lastName / emailAddress are consent-gated and may be
+        // omitted; a token carrying only `subject` must still parse.
+        const { privateKey } = generateRsaKeyPair();
+        const jwt: string = mintAccessToken(privateKey, { body: { subject: "subject-1" } });
+        const parsed = parseAccessToken(jwt);
+
+        if (parsed === null) {
+
+            throw new Error("expected a parsed token");
+        }
+
+        expect(parsed.body.subject).toBe("subject-1");
+        expect(parsed.body.firstName).toBeUndefined();
+        expect(parsed.body.lastName).toBeUndefined();
+        expect(parsed.body.emailAddress).toBeUndefined();
+    });
 });
 
 describe("parseRefreshToken", () => {


### PR DESCRIPTION
Bump the specs submodule (connect 0.4.0, native 0.3.0) and regenerate the
TypeScript and Python models. The regenerated output also picks up earlier
spec changes that had never been regenerated (Steam/OAuth/account-alias/
sector-subject payloads, DIRECT_ISSUE/OIDC return methods, HealthResponse).

Spec change: AccessTokenBody.firstName is no longer required — firstName,
lastName, and emailAddress are now consent-gated (claim sharing) and may be
absent. Update the hand-written token SDKs accordingly so tokens that omit
these claims parse instead of failing validation:

- Python: firstName str -> str | None (was a Pydantic-required field that
  raised ValidationError on absence)
- C#: FirstName required -> nullable (System.Text.Json threw on missing
  required members)
- TypeScript: firstName -> optional (declared type previously lied)
- Go: add omitempty to firstName for consistency
- Java: document the optional/consent-gated semantics (already nullable)

New genuine spec additions: BATTLENET_OAUTH / X_OAUTH auth-rule payloads
and additional error reasons (InquiryExpired, AccountDisabled,
AccountDeleted, ClaimConsentRequired, refresh AccountNotFound). Hand-written
clients treat reason codes as opaque strings, so only the generated schemas
needed updating.

Add regression tests (Python, TypeScript, Go) verifying an access token
carrying only `subject` parses with the consent-gated claims absent.

https://claude.ai/code/session_01WPzCiGdLoJ3oV6ph7izVqG